### PR TITLE
Add NSA_RSSI to configured sensors

### DIFF
--- a/custom_components/ha_zyxel/sensor.py
+++ b/custom_components/ha_zyxel/sensor.py
@@ -107,6 +107,13 @@ KNOWN_SENSORS = {
         "device_class": SensorDeviceClass.SIGNAL_STRENGTH,
         "state_class": SensorStateClass.MEASUREMENT
     },
+    "NSA_RSSI": {
+        "name": "NSA Reference Signal Strength Indicator",
+        "unit": "dBm",
+        "icon": "mdi:signal",
+        "device_class": SensorDeviceClass.SIGNAL_STRENGTH,
+        "state_class": SensorStateClass.MEASUREMENT
+    },
     "NSA_SINR": {
         "name": "NSA Signal-to-Noise Ratio",
         "unit": "dB",


### PR DESCRIPTION
Currently RSSI for 5G signal is not configured and doesn't look great in Logview:
<img width="215" height="216" alt="image" src="https://github.com/user-attachments/assets/d9328abe-40b4-49e3-bd0b-f099eaa1b40e" />

Here's the comparison with 4G RSSI:
<img width="934" height="192" alt="image" src="https://github.com/user-attachments/assets/e366a6e7-1545-41ee-bf1a-c37e0aa38bb6" />

