### PR TITLE
Add device tracking + per-client sensors, and fix connection dropping

### DIFF
--- a/custom_components/ha_zyxel/__init__.py
+++ b/custom_components/ha_zyxel/__init__.py
@@ -3,7 +3,6 @@ import asyncio
 import logging
 from datetime import timedelta
 
-import async_timeout
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
@@ -25,49 +24,66 @@ nr7101_logger.setLevel(logging.WARNING)
 
 from nr7101 import nr7101
 
-PLATFORMS = ["sensor", "button"]
+PLATFORMS = ["sensor", "button", "device_tracker", "binary_sensor"]
+
+# Bound every HTTP call. nr7101 sets no request timeouts, so a single hung
+# request would otherwise pile up worker threads that share the router's one
+# session and desync its AES key (shows up as "decrypt" errors that never heal).
+REQUEST_TIMEOUT = 15
+
+
+def _new_router(host, username, password):
+    """Create an nr7101 client with a per-request timeout applied to every call."""
+    return nr7101.NR7101(host, username, password, {"timeout": REQUEST_TIMEOUT})
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Zyxel integration from a config entry."""
-
-
     host = entry.data[CONF_HOST]
     username = entry.data[CONF_USERNAME]
     password = entry.data[CONF_PASSWORD]
 
     try:
-        router = await hass.async_add_executor_job(
-            nr7101.NR7101, host, username, password
-        )
+        router = await hass.async_add_executor_job(_new_router, host, username, password)
     except Exception as ex:
         _LOGGER.error("Could not connect to Zyxel router: %s", ex)
         raise ConfigEntryNotReady from ex
 
-    async def async_update_data():
-        """Fetch data from the router."""
+    state = {"router": router}
+    scan_interval = entry.options.get("scan_interval", DEFAULT_SCAN_INTERVAL)
+
+    def _fetch():
+        """Fetch router data; on failure recreate the session once and retry (self-heal)."""
+        client = state["router"]
         try:
-            async with async_timeout.timeout(15):
-                def get_all_data():
-                    data = router.get_status()
+            data = client.get_status()
+        except Exception as err:  # noqa: BLE001 - desync/timeout/etc.
+            _LOGGER.debug("Zyxel fetch failed, recreating session: %s", err)
+            data = None
+        if not data:
+            client = _new_router(host, username, password)
+            state["router"] = client
+            data = client.get_status()
+        if not data:
+            raise UpdateFailed("No data received from router")
+        if "device" not in data or not data["device"]:
+            try:
+                device_info = client.get_json_object("status")
+                if device_info:
+                    data["device_info"] = device_info
+            except Exception:  # noqa: BLE001 - optional extra info
+                pass
+        return data
 
-                    if not data:
-                        raise UpdateFailed("No data received from router")
-
-                    # Get device info if not already in data
-                    if "device" not in data or not data["device"]:
-                        device_info = router.get_json_object("status")
-                        if device_info:
-                            data["device_info"] = device_info
-
-                    return data
-
-                return await hass.async_add_executor_job(get_all_data)
-        except asyncio.TimeoutError:
-            router._session_valid = False
-            raise UpdateFailed("Router data fetch timed out")
+    async def async_update_data():
+        # No asyncio timeout wrapper: each HTTP call is bounded by REQUEST_TIMEOUT
+        # and DataUpdateCoordinator serialises refreshes, so the executor job always
+        # finishes before the next one starts -> no overlapping threads / session desync.
+        try:
+            return await hass.async_add_executor_job(_fetch)
+        except UpdateFailed:
+            raise
         except Exception as err:
-            router._session_valid = False
             raise UpdateFailed(f"Error communicating with router: {err}") from err
 
     coordinator = DataUpdateCoordinator(
@@ -75,7 +91,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         _LOGGER,
         name=DOMAIN,
         update_method=async_update_data,
-        update_interval=timedelta(seconds=DEFAULT_SCAN_INTERVAL),
+        update_interval=timedelta(seconds=scan_interval),
     )
 
     await coordinator.async_config_entry_first_refresh()
@@ -84,11 +100,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data[DOMAIN][entry.entry_id] = {
         "coordinator": coordinator,
         "router": router,
+        "state": state,
     }
 
+    entry.async_on_unload(entry.add_update_listener(_async_update_listener))
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
-
     return True
+
+
+async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Reload the entry when its options change (scan interval, etc.)."""
+    await hass.config_entries.async_reload(entry.entry_id)
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/ha_zyxel/binary_sensor.py
+++ b/custom_components/ha_zyxel/binary_sensor.py
@@ -1,0 +1,71 @@
+"""Connectivity binary sensor for Zyxel LAN hosts (instant online/offline).
+
+Unlike the device_tracker (which applies a consider-home grace period), this
+reports the router's raw association state immediately - handy for automations
+that want to react the moment a device drops off or joins the network.
+"""
+from __future__ import annotations
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntity,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from custom_components.ha_zyxel.const import DOMAIN
+from custom_components.ha_zyxel.helpers import lan_hosts
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Create a connectivity sensor per LAN host, picking up new ones over time."""
+    coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
+    tracked: set[str] = set()
+
+    @callback
+    def _discover() -> None:
+        new = [
+            ZyxelConnectivitySensor(coordinator, mac)
+            for mac in lan_hosts(coordinator)
+            if mac not in tracked
+        ]
+        for ent in new:
+            tracked.add(ent.mac)
+        if new:
+            async_add_entities(new)
+
+    entry.async_on_unload(coordinator.async_add_listener(_discover))
+    _discover()
+
+
+class ZyxelConnectivitySensor(CoordinatorEntity, BinarySensorEntity):
+    """Instant online/offline for one LAN host (no consider-home debounce)."""
+
+    _attr_has_entity_name = True
+    _attr_name = "Connected"
+    _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
+    # Secondary/opt-in entity so it doesn't double the entity count by default.
+    _attr_entity_registry_enabled_default = False
+
+    def __init__(self, coordinator, mac: str) -> None:
+        """Initialise the connectivity sensor for one MAC address."""
+        super().__init__(coordinator)
+        self.mac = mac
+        self._attr_unique_id = f"{mac}_connectivity"
+        host = lan_hosts(coordinator).get(mac, {})
+        friendly = host.get("curHostName") or host.get("HostName") or mac
+        self._attr_device_info = DeviceInfo(
+            connections={(CONNECTION_NETWORK_MAC, mac)},
+            default_name=friendly,
+        )
+
+    @property
+    def is_on(self) -> bool:
+        """True while the router reports the device as currently active."""
+        return bool(lan_hosts(self.coordinator).get(self.mac, {}).get("Active"))

--- a/custom_components/ha_zyxel/config_flow.py
+++ b/custom_components/ha_zyxel/config_flow.py
@@ -6,7 +6,17 @@ import voluptuous as vol
 from homeassistant import config_entries, core, exceptions
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
 
-from .const import DEFAULT_HOST, DEFAULT_USERNAME, DOMAIN
+from .const import (
+    CONF_CONSIDER_HOME,
+    CONF_SCAN_INTERVAL,
+    CONF_TRACK_ALL,
+    DEFAULT_CONSIDER_HOME,
+    DEFAULT_HOST,
+    DEFAULT_SCAN_INTERVAL,
+    DEFAULT_TRACK_ALL,
+    DEFAULT_USERNAME,
+    DOMAIN,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -56,6 +66,12 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     VERSION = 1
     CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
 
+    @staticmethod
+    @core.callback
+    def async_get_options_flow(config_entry):
+        """Return the options flow handler."""
+        return OptionsFlowHandler()
+
     async def async_step_user(self, user_input=None):
         """Handle the initial step."""
         errors = {}
@@ -94,6 +110,34 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             return self.async_show_form(
                 step_id="user", data_schema=DATA_SCHEMA, errors=errors
             )
+
+
+class OptionsFlowHandler(config_entries.OptionsFlow):
+    """Handle Zyxel options: poll interval, consider-home, and track-all."""
+
+    async def async_step_init(self, user_input=None):
+        """Manage the options."""
+        if user_input is not None:
+            return self.async_create_entry(title="", data=user_input)
+
+        opts = self.config_entry.options
+        schema = vol.Schema(
+            {
+                vol.Optional(
+                    CONF_SCAN_INTERVAL,
+                    default=opts.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL),
+                ): vol.All(vol.Coerce(int), vol.Range(min=10, max=3600)),
+                vol.Optional(
+                    CONF_CONSIDER_HOME,
+                    default=opts.get(CONF_CONSIDER_HOME, DEFAULT_CONSIDER_HOME),
+                ): vol.All(vol.Coerce(int), vol.Range(min=0, max=86400)),
+                vol.Optional(
+                    CONF_TRACK_ALL,
+                    default=opts.get(CONF_TRACK_ALL, DEFAULT_TRACK_ALL),
+                ): bool,
+            }
+        )
+        return self.async_show_form(step_id="init", data_schema=schema)
 
 
 class ConnectionError(exceptions.HomeAssistantError):

--- a/custom_components/ha_zyxel/const.py
+++ b/custom_components/ha_zyxel/const.py
@@ -7,3 +7,10 @@ DEFAULT_SCAN_INTERVAL = 30
 CONF_HOST = "host"
 CONF_USERNAME = "username"
 CONF_PASSWORD = "password"
+
+# Options (configurable via the integration's "Configure" dialog)
+CONF_SCAN_INTERVAL = "scan_interval"
+CONF_CONSIDER_HOME = "consider_home"
+CONF_TRACK_ALL = "track_all"
+DEFAULT_CONSIDER_HOME = 300
+DEFAULT_TRACK_ALL = False

--- a/custom_components/ha_zyxel/device_tracker.py
+++ b/custom_components/ha_zyxel/device_tracker.py
@@ -1,0 +1,175 @@
+"""Device tracker platform for Zyxel routers (LAN hosts / presence detection)."""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, timezone
+
+from homeassistant.components.device_tracker import ScannerEntity, SourceType
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.helpers import entity_registry as er
+
+from custom_components.ha_zyxel.const import (
+    CONF_CONSIDER_HOME,
+    CONF_TRACK_ALL,
+    DEFAULT_CONSIDER_HOME,
+    DEFAULT_TRACK_ALL,
+    DOMAIN,
+)
+from custom_components.ha_zyxel.helpers import lan_hosts
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Create a tracker for every LAN host and pick up new ones as they appear."""
+    coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
+    consider_home = entry.options.get(CONF_CONSIDER_HOME, DEFAULT_CONSIDER_HOME)
+    track_all = entry.options.get(CONF_TRACK_ALL, DEFAULT_TRACK_ALL)
+
+    # "Track all" on: re-enable trackers we auto-disabled, but leave the ones the
+    # user disabled by hand alone.
+    if track_all:
+        registry = er.async_get(hass)
+        for reg in er.async_entries_for_config_entry(registry, entry.entry_id):
+            if (
+                reg.domain == "device_tracker"
+                and reg.disabled_by == er.RegistryEntryDisabler.INTEGRATION
+            ):
+                registry.async_update_entity(reg.entity_id, disabled_by=None)
+
+    tracked: set[str] = set()
+
+    @callback
+    def _discover() -> None:
+        new = [
+            ZyxelDeviceTracker(coordinator, entry, mac, consider_home, track_all)
+            for mac in lan_hosts(coordinator)
+            if mac not in tracked
+        ]
+        for ent in new:
+            tracked.add(ent.mac_address)
+        if new:
+            async_add_entities(new)
+
+    entry.async_on_unload(coordinator.async_add_listener(_discover))
+    _discover()
+
+
+class ZyxelDeviceTracker(CoordinatorEntity, ScannerEntity):
+    """A single LAN client seen by the Zyxel router."""
+
+    _attr_should_poll = False
+    _attr_has_entity_name = False
+
+    def __init__(
+        self,
+        coordinator,
+        entry: ConfigEntry,
+        mac: str,
+        consider_home: int,
+        track_all: bool = False,
+    ) -> None:
+        """Initialise the tracker for one MAC address."""
+        super().__init__(coordinator)
+        self._mac = mac
+        self._consider_home = timedelta(seconds=consider_home)
+        self._track_all = track_all
+        self._last_seen: datetime | None = None
+        self._attr_unique_id = mac
+        self._update_last_seen()
+
+        friendly = self._friendly_name()
+        self._attr_name = friendly
+        # MAC connection lets HA merge this onto an existing device of the same MAC.
+        self._attr_device_info = DeviceInfo(
+            connections={(CONNECTION_NETWORK_MAC, mac)},
+            default_name=friendly,
+        )
+
+    @property
+    def _host(self) -> dict:
+        """Current router record for this MAC (empty dict once it disappears)."""
+        return lan_hosts(self.coordinator).get(self._mac, {})
+
+    def _friendly_name(self) -> str:
+        host = self._host
+        return (
+            host.get("curHostName")
+            or host.get("HostName")
+            or host.get("DeviceName")
+            or self._mac
+        )
+
+    def _update_last_seen(self) -> None:
+        if self._host.get("Active"):
+            self._last_seen = datetime.now(timezone.utc)
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        self._update_last_seen()
+        super()._handle_coordinator_update()
+
+    @property
+    def source_type(self) -> SourceType:
+        return SourceType.ROUTER
+
+    @property
+    def entity_registry_enabled_default(self) -> bool:
+        # Default (like AsusWRT): only devices HA already knows by MAC are enabled.
+        # With the "track all" option on, enable every discovered device.
+        if self._track_all:
+            return True
+        return super().entity_registry_enabled_default
+
+    @property
+    def is_connected(self) -> bool:
+        """Home if active now, or last seen within the consider-home window."""
+        if self._host.get("Active"):
+            return True
+        if self._last_seen is None:
+            return False
+        return datetime.now(timezone.utc) - self._last_seen <= self._consider_home
+
+    @property
+    def mac_address(self) -> str:
+        return self._mac
+
+    @property
+    def ip_address(self) -> str | None:
+        return self._host.get("IPAddress") or None
+
+    @property
+    def hostname(self) -> str | None:
+        host = self._host
+        return host.get("curHostName") or host.get("HostName") or None
+
+    @property
+    def extra_state_attributes(self) -> dict:
+        host = self._host
+        layer1 = host.get("Layer1Interface") or ""
+        is_wifi = "WiFi" in layer1
+        ssid_index = layer1.rsplit(".", 1)[-1] if (is_wifi and "." in layer1) else None
+        network = None
+        if is_wifi and "X_ZYXEL_MainSSID" in host:
+            network = "main" if host.get("X_ZYXEL_MainSSID") else "guest"
+        return {
+            "ip_address": host.get("IPAddress") or None,
+            "connection": "wifi" if is_wifi else ("ethernet" if layer1 else None),
+            "band": host.get("SupportedFrequencyBands") or None,
+            "network": network,
+            "ssid_index": ssid_index,
+            # WiFiname is the SSID name, not a device name.
+            "ssid_name": (host.get("WiFiname") or None) if is_wifi else None,
+            "access_point": host.get("X_ZYXEL_ConnectedAP") or None,
+            "rssi": host.get("X_ZYXEL_RSSI") if is_wifi else None,
+            "link_rate_mbps": host.get("X_ZYXEL_PhyRate"),
+            "standard": host.get("X_ZYXEL_OperatingStandard") or None,
+            "last_seen": self._last_seen.isoformat() if self._last_seen else None,
+        }

--- a/custom_components/ha_zyxel/helpers.py
+++ b/custom_components/ha_zyxel/helpers.py
@@ -1,0 +1,17 @@
+"""Shared helpers for the Zyxel integration."""
+from __future__ import annotations
+
+from homeassistant.helpers.device_registry import format_mac
+
+
+def lan_hosts(coordinator) -> dict[str, dict]:
+    """Return {formatted_mac: host_record} from the coordinator's lanhosts data."""
+    block = (coordinator.data or {}).get("lanhosts")
+    hosts = block.get("lanhosts") if isinstance(block, dict) else None
+    result: dict[str, dict] = {}
+    if isinstance(hosts, list):
+        for host in hosts:
+            mac = host.get("PhysAddress")
+            if mac:
+                result[format_mac(mac)] = host
+    return result

--- a/custom_components/ha_zyxel/sensor.py
+++ b/custom_components/ha_zyxel/sensor.py
@@ -10,12 +10,15 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from custom_components.ha_zyxel.const import DOMAIN
+from custom_components.ha_zyxel.helpers import lan_hosts
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -180,47 +183,48 @@ async def async_setup_entry(
     """Set up the Zyxel sensors."""
     coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
 
-    if not coordinator.data:
-        return
-
+    # Router telemetry sensors (flattened from the status data), created once.
     sensors = []
-
-    # Process all keys in the JSON and create sensors for them
-    # We'll use a flat structure for simplicity
-    for key, value in _flatten_dict(coordinator.data).items():
-        # Skip non-scalar values
+    for key, value in _flatten_dict(coordinator.data or {}).items():
         if not _is_value_scalar(value):
             continue
-
-        # Check if this is a known sensor type
         sensor_config = KNOWN_SENSORS.get(key.split(".")[-1], None)
-
         if sensor_config:
-            # Create a configured sensor for known types
-            sensors.append(
-                ConfiguredZyxelSensor(
-                    coordinator,
-                    entry,
-                    key,
-                    sensor_config
-                )
-            )
+            sensors.append(ConfiguredZyxelSensor(coordinator, entry, key, sensor_config))
         else:
-            # Create a generic sensor for unknown types
-            sensors.append(
-                GenericZyxelSensor(
-                    coordinator,
-                    entry,
-                    key
-                )
-            )
+            sensors.append(GenericZyxelSensor(coordinator, entry, key))
 
-    if sensors:
-        async_add_entities(sensors)
+    # Router-level primary sensor: number of connected clients.
+    sensors.append(ZyxelConnectedClients(coordinator, entry))
+    async_add_entities(sensors)
+
+    # Per-client diagnostic sensors (signal / link rate), discovered dynamically.
+    tracked: set[str] = set()
+
+    @callback
+    def _discover_clients() -> None:
+        new = []
+        for mac in lan_hosts(coordinator):
+            if mac not in tracked:
+                tracked.add(mac)
+                new.extend(
+                    ZyxelClientAttrSensor(coordinator, mac, spec)
+                    for spec in CLIENT_SENSOR_SPECS
+                )
+        if new:
+            async_add_entities(new)
+
+    entry.async_on_unload(coordinator.async_add_listener(_discover_clients))
+    _discover_clients()
 
 
 class AbstractZyxelSensor(CoordinatorEntity, SensorEntity):
     """Base class for Zyxel device sensors."""
+
+    # Auto-generated router telemetry: treat as diagnostic and keep the long tail
+    # off by default. Curated (Configured) sensors re-enable themselves below.
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_entity_registry_enabled_default = False
 
     def __init__(self, coordinator, entry: ConfigEntry, key: str):
         """Initialize the sensor."""
@@ -257,7 +261,10 @@ class AbstractZyxelSensor(CoordinatorEntity, SensorEntity):
 
 
 class ConfiguredZyxelSensor(AbstractZyxelSensor):
-    """Representation of a configured Zyxel sensor."""
+    """Representation of a configured (curated) Zyxel sensor."""
+
+    # Curated sensors are useful enough to stay enabled (still diagnostic).
+    _attr_entity_registry_enabled_default = True
 
     def __init__(self, coordinator, entry: ConfigEntry, key: str, config: dict):
         """Initialize the sensor."""
@@ -299,3 +306,140 @@ class GenericZyxelSensor(AbstractZyxelSensor):
     def icon(self):
         """Return the icon."""
         return "mdi:router-wireless"
+
+
+class ZyxelConnectedClients(CoordinatorEntity, SensorEntity):
+    """Number of devices currently connected to the router."""
+
+    _attr_icon = "mdi:lan-connect"
+    _attr_name = "Connected devices"
+    _attr_state_class = SensorStateClass.MEASUREMENT
+
+    def __init__(self, coordinator, entry: ConfigEntry):
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{entry.entry_id}_connected_clients"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, entry.entry_id)},
+            name=f"Zyxel ({entry.data['host']})",
+            manufacturer="Zyxel",
+        )
+
+    @property
+    def native_value(self) -> int:
+        return sum(1 for h in lan_hosts(self.coordinator).values() if h.get("Active"))
+
+
+class _ZyxelClientSensor(CoordinatorEntity, SensorEntity):
+    """Base for per-client diagnostic sensors (attached to the client's device)."""
+
+    _attr_has_entity_name = True
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_entity_registry_enabled_default = False
+
+    def __init__(self, coordinator, mac: str):
+        super().__init__(coordinator)
+        self._mac = mac
+        host = lan_hosts(coordinator).get(mac, {})
+        friendly = host.get("curHostName") or host.get("HostName") or mac
+        self._attr_device_info = DeviceInfo(
+            connections={(CONNECTION_NETWORK_MAC, mac)},
+            default_name=friendly,
+        )
+
+    @property
+    def _host(self) -> dict:
+        return lan_hosts(self.coordinator).get(self._mac, {})
+
+
+def _is_wifi(host: dict) -> bool:
+    return "WiFi" in (host.get("Layer1Interface") or "")
+
+
+def _nz(value):
+    """Treat 0 / empty as no reading (avoids fake -0 dBm etc.)."""
+    return value if value not in (None, 0, "") else None
+
+
+def _wifi_only(fn):
+    """Only return a value for Wi-Fi clients (None for wired)."""
+    return lambda host: (fn(host) if _is_wifi(host) else None)
+
+
+def _kbps_to_mbps(value):
+    return round(value / 1000, 1) if isinstance(value, (int, float)) and value else None
+
+
+# Per-client diagnostic sensors, one entity each. All disabled by default; enable
+# the ones you want per device. "id" is stable — it forms the entity unique_id.
+CLIENT_SENSOR_SPECS: list[dict] = [
+    {"id": "rssi", "name": "Signal strength", "device_class": SensorDeviceClass.SIGNAL_STRENGTH,
+     "unit": "dBm", "state_class": SensorStateClass.MEASUREMENT,
+     "fn": _wifi_only(lambda h: _nz(h.get("X_ZYXEL_RSSI")))},
+    {"id": "snr", "name": "Signal-to-noise ratio", "unit": "dB", "icon": "mdi:signal",
+     "state_class": SensorStateClass.MEASUREMENT,
+     "fn": _wifi_only(lambda h: _nz(h.get("X_ZYXEL_SNR")))},
+    {"id": "signal_quality", "name": "Signal quality", "unit": "%", "icon": "mdi:signal",
+     "state_class": SensorStateClass.MEASUREMENT,
+     "fn": _wifi_only(lambda h: _nz(h.get("X_ZYXEL_SignalStrength")))},
+    {"id": "link_rate", "name": "Link rate", "device_class": SensorDeviceClass.DATA_RATE,
+     "unit": "Mbit/s", "state_class": SensorStateClass.MEASUREMENT,
+     "fn": lambda h: h.get("X_ZYXEL_PhyRate")},
+    {"id": "downlink_rate", "name": "Downlink rate", "device_class": SensorDeviceClass.DATA_RATE,
+     "unit": "Mbit/s", "state_class": SensorStateClass.MEASUREMENT,
+     "fn": lambda h: _kbps_to_mbps(h.get("X_ZYXEL_LastDataDownlinkRate"))},
+    {"id": "uplink_rate", "name": "Uplink rate", "device_class": SensorDeviceClass.DATA_RATE,
+     "unit": "Mbit/s", "state_class": SensorStateClass.MEASUREMENT,
+     "fn": lambda h: _kbps_to_mbps(h.get("X_ZYXEL_LastDataUplinkRate"))},
+    {"id": "bytes_received", "name": "Bytes received", "device_class": SensorDeviceClass.DATA_SIZE,
+     "unit": "B", "state_class": SensorStateClass.TOTAL_INCREASING,
+     "fn": lambda h: h.get("X_ZYXEL_BytesReceived")},
+    {"id": "bytes_sent", "name": "Bytes sent", "device_class": SensorDeviceClass.DATA_SIZE,
+     "unit": "B", "state_class": SensorStateClass.TOTAL_INCREASING,
+     "fn": lambda h: h.get("X_ZYXEL_BytesSent")},
+    {"id": "connected_duration", "name": "Connected duration",
+     "device_class": SensorDeviceClass.DURATION, "unit": "s",
+     "state_class": SensorStateClass.MEASUREMENT,
+     "fn": lambda h: h.get("X_ZYXEL_Duration")},
+    {"id": "ip_address", "name": "IP address", "icon": "mdi:ip-network",
+     "fn": lambda h: h.get("IPAddress") or None},
+    {"id": "ssid", "name": "SSID", "icon": "mdi:wifi",
+     "fn": _wifi_only(lambda h: h.get("WiFiname") or None)},
+    {"id": "band", "name": "Band", "icon": "mdi:wifi",
+     "fn": _wifi_only(lambda h: h.get("SupportedFrequencyBands") or None)},
+    {"id": "network", "name": "Network", "icon": "mdi:wifi-cog",
+     "fn": _wifi_only(lambda h: ("main" if h.get("X_ZYXEL_MainSSID") else "guest")
+                      if "X_ZYXEL_MainSSID" in h else None)},
+    {"id": "wifi_standard", "name": "Wi-Fi standard", "icon": "mdi:wifi",
+     "fn": _wifi_only(lambda h: h.get("X_ZYXEL_OperatingStandard") or None)},
+    {"id": "connection_type", "name": "Connection type", "icon": "mdi:lan",
+     "fn": lambda h: ("wifi" if _is_wifi(h) else ("ethernet" if h.get("Layer1Interface") else None))},
+    {"id": "device_type", "name": "Device type", "icon": "mdi:devices",
+     "fn": lambda h: h.get("X_ZYXEL_HostType") or None},
+    {"id": "address_source", "name": "Address source", "icon": "mdi:ip",
+     "fn": lambda h: h.get("AddressSource") or None},
+]
+
+
+class ZyxelClientAttrSensor(_ZyxelClientSensor):
+    """One diagnostic value for a client, driven by a CLIENT_SENSOR_SPECS entry."""
+
+    def __init__(self, coordinator, mac: str, spec: dict):
+        super().__init__(coordinator, mac)
+        self._value_fn = spec["fn"]
+        self._attr_unique_id = f"{mac}_{spec['id']}"
+        self._attr_name = spec["name"]
+        if spec.get("device_class"):
+            self._attr_device_class = spec["device_class"]
+        if spec.get("unit"):
+            self._attr_native_unit_of_measurement = spec["unit"]
+        if spec.get("state_class"):
+            self._attr_state_class = spec["state_class"]
+        if spec.get("icon"):
+            self._attr_icon = spec["icon"]
+
+    @property
+    def native_value(self):
+        try:
+            return self._value_fn(self._host)
+        except Exception:  # noqa: BLE001 - one bad client must not break the platform
+            return None

--- a/custom_components/ha_zyxel/translations/en.json
+++ b/custom_components/ha_zyxel/translations/en.json
@@ -17,5 +17,22 @@
     "abort": {
       "already_configured": "Device is already configured"
     }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Zyxel options",
+        "data": {
+          "scan_interval": "Scan interval (seconds)",
+          "consider_home": "Consider home (seconds)",
+          "track_all": "Track all discovered devices"
+        },
+        "data_description": {
+          "scan_interval": "How often to poll the router for connected devices (10-3600).",
+          "consider_home": "How long a device may be unseen before it is marked away.",
+          "track_all": "Create an enabled tracker for every device the router sees, not just ones Home Assistant already knows."
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
Adds presence detection and per-client sensors, and fixes the integration losing its connection to the router.

New
- device_tracker per LAN client (source_type: router, with consider_home)
- binary_sensor connectivity per client
- Per-client diagnostic sensors: signal strength, link rate, up/down rate,
  bytes, connected time, SSID, band, network (main/guest), IP, standard, etc.
- "Connected devices" count sensor.
- Options flow: scan interval, consider_home, track_all.

Fixed
- nr7101 makes its HTTP calls with no timeout, and the coordinator wrapped them in a 15s async timeout that abandoned the still-running worker thread. Overlapping threads then shared the router's single session and desynced its AES key, spamming "decrypt" errors until a restart. Now every request has a timeout, threads aren't abandoned, and the session is recreated on failure. It is still a bit work in progress but should already be better

Tested on AX7501-B1 (firmware V5.17).

Closes #46. Should also fix the connection failures in #45, #47, #52.