### PR TITLE
I fixed the session/decryption flow in the local integration.

### DIFF
--- a/custom_components/ha_zyxel/__init__.py
+++ b/custom_components/ha_zyxel/__init__.py
@@ -9,6 +9,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
+from custom_components.ha_zyxel.api import create_router, fetch_status
 from custom_components.ha_zyxel.const import (
     CONF_HOST,
     CONF_PASSWORD,
@@ -23,8 +24,6 @@ _LOGGER = logging.getLogger(__name__)
 nr7101_logger = logging.getLogger("nr7101.nr7101")
 nr7101_logger.setLevel(logging.WARNING)
 
-from nr7101 import nr7101
-
 PLATFORMS = ["sensor", "button"]
 
 
@@ -38,7 +37,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     try:
         router = await hass.async_add_executor_job(
-            nr7101.NR7101, host, username, password
+            create_router, host, username, password
         )
     except Exception as ex:
         _LOGGER.error("Could not connect to Zyxel router: %s", ex)
@@ -49,25 +48,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         try:
             async with async_timeout.timeout(15):
                 def get_all_data():
-                    data = router.get_status()
+                    data = fetch_status(router)
 
                     if not data:
                         raise UpdateFailed("No data received from router")
-
-                    # Get device info if not already in data
-                    if "device" not in data or not data["device"]:
-                        device_info = router.get_json_object("status")
-                        if device_info:
-                            data["device_info"] = device_info
 
                     return data
 
                 return await hass.async_add_executor_job(get_all_data)
         except asyncio.TimeoutError:
-            router._session_valid = False
+            router.sessionkey = None
             raise UpdateFailed("Router data fetch timed out")
         except Exception as err:
-            router._session_valid = False
+            router.sessionkey = None
             raise UpdateFailed(f"Error communicating with router: {err}") from err
 
     coordinator = DataUpdateCoordinator(

--- a/custom_components/ha_zyxel/api.py
+++ b/custom_components/ha_zyxel/api.py
@@ -1,0 +1,110 @@
+"""Synchronous helpers for communicating with Zyxel devices."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from nr7101 import nr7101
+
+_LOGGER = logging.getLogger(__name__)
+
+_ENDPOINTS = (
+    ("cellwan_status", "cellular"),
+    ("Traffic_Status", "traffic"),
+    ("cardpage_status", "cardpage"),
+    ("lan", "lan"),
+    ("lanhosts", "lanhosts"),
+    ("wifi_easy_mesh", "wifi_mesh"),
+    ("one_connect", "one_connect"),
+    ("status", "device"),
+)
+
+
+class ZyxelAuthenticationError(Exception):
+    """Raised when the router rejects the supplied credentials."""
+
+
+class ZyxelConnectionError(Exception):
+    """Raised when no usable data can be fetched from the router."""
+
+
+def create_router(host: str, username: str, password: str) -> Any:
+    """Create a router with connection state isolated from other instances.
+
+    nr7101 currently uses a mutable dictionary as its default ``params``
+    argument. Passing a new dictionary explicitly prevents cookies from a
+    config-flow instance being reused by the config-entry instance, where
+    they would be paired with a different AES key.
+    """
+    return nr7101.NR7101(host, username, password, {})
+
+
+def authenticate(router: Any) -> None:
+    """Log in and verify that nr7101 received a session key."""
+    try:
+        login_success = router.login()
+    except Exception as err:
+        raise ZyxelConnectionError("Unable to complete router login") from err
+
+    if not login_success or not getattr(router, "sessionkey", None):
+        raise ZyxelAuthenticationError("The router rejected the credentials")
+
+
+def _parse_traffic_object(obj: dict[str, Any] | None) -> dict[str, Any]:
+    """Convert Traffic_Status interface arrays to a keyed dictionary."""
+    if not obj or "ipIface" not in obj or "ipIfaceSt" not in obj:
+        return {}
+
+    return {
+        interface["X_ZYXEL_IfName"]: status
+        for interface, status in zip(obj["ipIface"], obj["ipIfaceSt"])
+        if "X_ZYXEL_IfName" in interface
+    }
+
+
+def _fetch_available_endpoints(
+    router: Any,
+) -> tuple[dict[str, Any], Exception | None]:
+    """Fetch every supported endpoint once without an unbounded retry loop."""
+    result: dict[str, Any] = {}
+    last_error: Exception | None = None
+
+    for endpoint, key in _ENDPOINTS:
+        try:
+            data = router.get_json_object(endpoint)
+            if endpoint == "Traffic_Status":
+                data = _parse_traffic_object(data)
+            if data:
+                result[key] = data
+        except Exception as err:  # Different firmware exposes different endpoints.
+            last_error = err
+            _LOGGER.debug("Zyxel endpoint %s is unavailable: %s", endpoint, err)
+
+            # Invalid UTF-8 after AES decryption means the cookie/session and
+            # AES key no longer match. Continuing would emit the same error for
+            # every endpoint, so reauthenticate immediately.
+            if "Failed to process decrypted response" in str(err):
+                break
+
+    return result, last_error
+
+
+def fetch_status(router: Any) -> dict[str, Any]:
+    """Return available router data, reauthenticating once when necessary."""
+    if not getattr(router, "sessionkey", None):
+        authenticate(router)
+
+    last_error: Exception | None = None
+    for attempt in range(2):
+        result, last_error = _fetch_available_endpoints(router)
+        if result:
+            return result
+
+        if attempt == 0:
+            router.sessionkey = None
+            authenticate(router)
+
+    raise ZyxelConnectionError(
+        "The router returned no supported status data"
+    ) from last_error

--- a/custom_components/ha_zyxel/config_flow.py
+++ b/custom_components/ha_zyxel/config_flow.py
@@ -3,9 +3,15 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant import config_entries, core, exceptions
+from homeassistant import config_entries, core
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
 
+from .api import (
+    ZyxelAuthenticationError,
+    ZyxelConnectionError,
+    create_router,
+    fetch_status,
+)
 from .const import DEFAULT_HOST, DEFAULT_USERNAME, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
@@ -13,8 +19,6 @@ _LOGGER = logging.getLogger(__name__)
 # Block excessive nr7101 debug logging
 nr7101_logger = logging.getLogger("nr7101.nr7101")
 nr7101_logger.setLevel(logging.WARNING)
-
-from nr7101 import nr7101
 
 DATA_SCHEMA = vol.Schema(
     {
@@ -31,21 +35,18 @@ async def validate_input(hass: core.HomeAssistant, data):
     try:
         # Create router instance and test connection
         router = await hass.async_add_executor_job(
-            nr7101.NR7101,
+            create_router,
             data[CONF_HOST],
             data[CONF_USERNAME],
             data[CONF_PASSWORD]
         )
 
-        login_success = await hass.async_add_executor_job(router.get_status)
-        if not login_success:
-            raise Exception("Login failed - check credentials")
-
-
-
+        await hass.async_add_executor_job(fetch_status, router)
+    except (ZyxelAuthenticationError, ZyxelConnectionError):
+        raise
     except Exception as ex:
         _LOGGER.error("Unable to connect to Zyxel device: %s", ex)
-        raise ConnectionError from ex
+        raise ZyxelConnectionError from ex
 
     return {"title": f"Zyxel device: ({data[CONF_HOST]})"}
 
@@ -72,8 +73,10 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             try:
                 info = await validate_input(self.hass, user_input)
                 success = True
-            except Exception as e:  # pylint: disable=broad-except
-                _LOGGER.exception("First attempt failed", e)
+            except ZyxelAuthenticationError:
+                errors["base"] = "invalid_auth"
+            except ZyxelConnectionError as err:
+                _LOGGER.error("Connection attempt failed: %s", err)
                 errors["base"] = "cannot_connect"
 
             if not success and "https" not in user_input["host"]:
@@ -82,10 +85,12 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 try:
                     info = await validate_input(self.hass, user_input)
                     success = True
-                except ConnectionError:
+                except ZyxelAuthenticationError:
+                    errors["base"] = "invalid_auth"
+                except ZyxelConnectionError:
                     errors["base"] = "cannot_connect"
                 except Exception as e:  # pylint: disable=broad-except
-                    _LOGGER.exception("Second attempt failed", e)
+                    _LOGGER.exception("Second attempt failed: %s", e)
                     errors["base"] = "unknown"
 
         if success:
@@ -94,7 +99,3 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             return self.async_show_form(
                 step_id="user", data_schema=DATA_SCHEMA, errors=errors
             )
-
-
-class ConnectionError(exceptions.HomeAssistantError):
-    """Error to indicate we cannot connect."""

--- a/custom_components/ha_zyxel/manifest.json
+++ b/custom_components/ha_zyxel/manifest.json
@@ -10,5 +10,5 @@
   "requirements": [
     "nr7101@git+https://github.com/zulufoxtrot/nr7101.git@v2.0.2"
   ],
-  "version": "0.2.7"
+  "version": "0.2.8"
 }


### PR DESCRIPTION
The cause was stale cookies being reused with a newly generated AES key, followed by status requests before authentication. The dependency could then retry indefinitely, producing random UTF‑8 decoding errors. Zyxel’s protocol requires the AES key to persist for the associated session, as documented in this protocol analysis https://warlo.no/posts/2023-03-31-zyxel-reverse-engineering. The same error pattern is also reported in ha-zyxel issue #56 https://github.com/zulufoxtrot/ha-zyxel/issues/56. 

Changes:
- Isolated cookies for every router instance.
- Authenticate before fetching status.
- Added one bounded reauthentication attempt.
- Removed the infinite dependency polling path.
- Correctly invalidate sessionkey after failures.
- Report invalid credentials separately.
- Bumped the integration to 0.2.8. 

Relevant files: [api.py (line 32)](/ha-zyxel/custom_components/ha_zyxel/api.py:32), [config_flow.py (line 29)](/ha-zyxel/custom_components/ha_zyxel/config_flow.py:29), [__init__.py (line 40)](/ha-zyxel/custom_components/ha_zyxel/__init__.py:40), and [manifest.json (line 13)](/ha-zyxel/custom_components/ha_zyxel/manifest.json:13).