### PR TITLE
Improve EX3301-T0 and NWA50AX support, clean up entity names, and stabilize Zyxel onboarding

### DIFF
--- a/custom_components/ha_zyxel/__init__.py
+++ b/custom_components/ha_zyxel/__init__.py
@@ -1,7 +1,9 @@
 """The Zyxel integration."""
 import asyncio
 import logging
+from collections.abc import Mapping
 from datetime import timedelta
+from typing import Any
 
 import async_timeout
 from homeassistant.config_entries import ConfigEntry
@@ -9,8 +11,15 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from custom_components.ha_zyxel.api import create_router, fetch_status
+from custom_components.ha_zyxel.api import (
+    ZyxelAuthenticationError,
+    ZyxelConnectionError,
+    create_router,
+    fetch_status,
+)
+from custom_components.ha_zyxel.backend import EX3301T0Client, NWA50AXClient
 from custom_components.ha_zyxel.const import (
+    CONF_DEVICE_TYPE,
     CONF_HOST,
     CONF_PASSWORD,
     CONF_USERNAME,
@@ -27,40 +36,209 @@ nr7101_logger.setLevel(logging.WARNING)
 PLATFORMS = ["sensor", "button"]
 
 
+def _entry_host(entry: ConfigEntry) -> str:
+    host = entry.data.get(CONF_HOST, "")
+    if host.startswith(("http://", "https://")):
+        host = host.split("://", 1)[1]
+    return host.split("/", 1)[0]
+
+
+def _hostish_title(title: str) -> str:
+    return title.strip().lower().replace("(", "").replace(")", "")
+
+
+def _normalize_device_type(value: str | None) -> str:
+    """Normalize device type aliases to canonical internal ids."""
+    normalized = str(value or "legacy").strip().lower().replace("-", "_")
+    if normalized == "ex3301":
+        return "ex3301_t0"
+    return normalized
+
+
+def _leaf_values(data: Mapping | None) -> dict[str, object]:
+    if not data:
+        return {}
+    flat = _flatten_value(data)
+    leafs: dict[str, object] = {}
+    for path, value in flat.items():
+        leaf = path.split(".")[-1]
+        if leaf not in leafs:
+            leafs[leaf] = value
+    return leafs
+
+
+def _ex3301_wifi_signature(data: Mapping | None) -> tuple[tuple[str, bool, bool, str], ...]:
+    """Return a stable signature of EX3301 WiFi radio state for reload detection."""
+    if not data:
+        return ()
+    flat = _flatten_value(data)
+    radios: dict[str, dict[str, object]] = {}
+    for key, value in flat.items():
+        if ".WiFiInfo." not in key:
+            continue
+        prefix, leaf = key.rsplit(".", 1)
+        radios.setdefault(prefix, {})[leaf] = value
+
+    normalized: list[tuple[str, bool, bool, str]] = []
+    for prefix, fields in radios.items():
+        slot = prefix.split(".")[-1]
+        enabled = bool(fields.get("Enable"))
+        is_main = bool(fields.get("X_ZYXEL_MainSSID"))
+        band = str(fields.get("OperatingFrequencyBand") or "").strip()
+        normalized.append((slot, enabled, is_main, band))
+    return tuple(sorted(normalized))
+
+
+def _detected_model_from_data(entry: ConfigEntry, data: Mapping | None) -> str:
+    leafs = _leaf_values(data)
+    model = (
+        leafs.get("ModelName")
+        or leafs.get("ProductClass")
+        or leafs.get("HardwareVersion")
+        or entry.data.get("model")
+        or entry.data.get(CONF_DEVICE_TYPE, "")
+        or _entry_host(entry)
+    )
+    return str(model).upper().replace("_", "-")
+
+
+def _should_update_title_to_model(entry: ConfigEntry, model_title: str) -> bool:
+    normalized_title = _hostish_title(entry.title)
+    normalized_model = _hostish_title(model_title)
+    host = _entry_host(entry).lower()
+    device_type = str(entry.data.get(CONF_DEVICE_TYPE, "")).lower()
+    defaults = {
+        host,
+        device_type,
+        device_type.upper().lower(),
+        f"{host}:80",
+        f"{host}:443",
+        f"zyxel {host}",
+        f"zyxel {device_type}",
+        f"zyxel {device_type.upper()}".lower(),
+        f"zyxel {host}:80",
+        f"zyxel {host}:443",
+        "english",
+        "zyxel english",
+        f"zyxel {normalized_model}",
+    }
+    if entry.title.startswith("Zyxel "):
+        return entry.title.removeprefix("Zyxel ") != model_title
+    return normalized_title in defaults and entry.title != model_title
+
+
+def _flatten_value(value, parent_key: str = "") -> dict:
+    items = {}
+    if isinstance(value, Mapping):
+        for k, v in value.items():
+            key = f"{parent_key}.{k}" if parent_key else str(k)
+            items.update(_flatten_value(v, key))
+    elif isinstance(value, list):
+        for idx, v in enumerate(value):
+            key = f"{parent_key}.{idx}" if parent_key else str(idx)
+            items.update(_flatten_value(v, key))
+    else:
+        items[parent_key] = value
+    return items
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Zyxel integration from a config entry."""
-
 
     host = entry.data[CONF_HOST]
     username = entry.data[CONF_USERNAME]
     password = entry.data[CONF_PASSWORD]
+    raw_device_type = entry.data.get(CONF_DEVICE_TYPE, "legacy")
+    device_type = _normalize_device_type(raw_device_type)
+    if raw_device_type != device_type:
+        updated_data = dict(entry.data)
+        updated_data[CONF_DEVICE_TYPE] = device_type
+        hass.config_entries.async_update_entry(entry, data=updated_data)
+    if device_type in {"nwa50ax", "ex3301_t0"} and not host.startswith(("http://", "https://")):
+        host = f"http://{host}"
 
     try:
-        router = await hass.async_add_executor_job(
-            create_router, host, username, password
-        )
-    except Exception as ex:
-        _LOGGER.error("Could not connect to Zyxel router: %s", ex)
+        _LOGGER.debug("Creating Zyxel client for %s", host)
+        router: Any
+        if device_type == "nwa50ax":
+            router = NWA50AXClient(host, username, password)
+            await hass.async_add_executor_job(router.login)
+            await hass.async_add_executor_job(router.get_status)
+        elif device_type == "ex3301_t0":
+            router = EX3301T0Client(host, username, password)
+            await hass.async_add_executor_job(router.login)
+        else:
+            router = await hass.async_add_executor_job(
+                create_router, host, username, password
+            )
+    except (ZyxelAuthenticationError, ZyxelConnectionError) as ex:
+        _LOGGER.error("Could not connect to Zyxel device at %s: %s", host, ex)
         raise ConfigEntryNotReady from ex
+    except Exception as ex:
+        _LOGGER.error("Could not create Zyxel client for %s: %s", host, ex)
+        raise ConfigEntryNotReady from ex
+
+    # EX3301 probes each carry a 15s timeout; allow enough wall time for all of them.
+    _UPDATE_TIMEOUT = 180 if device_type == "ex3301_t0" else 15
 
     async def async_update_data():
         """Fetch data from the router."""
         try:
-            async with async_timeout.timeout(15):
+            async with async_timeout.timeout(_UPDATE_TIMEOUT):
                 def get_all_data():
+                    if device_type in {"nwa50ax", "ex3301_t0"}:
+                        data = router.get_status()
+                        if not data:
+                            raise UpdateFailed("No data received from router")
+                        return data
                     data = fetch_status(router)
-
                     if not data:
                         raise UpdateFailed("No data received from router")
-
                     return data
 
-                return await hass.async_add_executor_job(get_all_data)
+                result = await hass.async_add_executor_job(get_all_data)
+                if device_type == "ex3301_t0":
+                    runtime = hass.data.get(DOMAIN, {}).get(entry.entry_id)
+                    if runtime is not None:
+                        prev = runtime.get("wifi_signature")
+                        new = _ex3301_wifi_signature(result)
+                        runtime["wifi_signature"] = new
+                        if (
+                            prev is not None
+                            and prev != new
+                            and not runtime.get("wifi_reload_pending")
+                        ):
+                            runtime["wifi_reload_pending"] = True
+                            _LOGGER.info(
+                                "EX3301 WiFi state layout changed; reloading entry to refresh entities"
+                            )
+                            hass.async_create_task(hass.config_entries.async_reload(entry.entry_id))
+                return result
         except asyncio.TimeoutError:
-            router.sessionkey = None
+            if not device_type in {"nwa50ax", "ex3301_t0"}:
+                router.sessionkey = None
             raise UpdateFailed("Router data fetch timed out")
+        except UpdateFailed as err:
+            # Re-login and retry once if the EX3301 session has expired.
+            if device_type == "ex3301_t0" and "session expired" in str(err).lower():
+                _LOGGER.info("EX3301-T0 session expired — re-logging in and retrying")
+                try:
+                    await hass.async_add_executor_job(router.login)
+                    return await hass.async_add_executor_job(router.get_status)
+                except Exception as relogin_err:
+                    raise UpdateFailed(f"EX3301-T0 re-login failed: {relogin_err}") from relogin_err
+            if device_type == "nwa50ax" and "login failed" in str(err).lower():
+                _LOGGER.info("NWA50AX login failed — re-logging in and retrying")
+                try:
+                    await hass.async_add_executor_job(router.login)
+                    return await hass.async_add_executor_job(router.get_status)
+                except Exception as relogin_err:
+                    raise UpdateFailed(f"NWA50AX re-login failed: {relogin_err}") from relogin_err
+            raise
         except Exception as err:
-            router.sessionkey = None
+            if not device_type in {"nwa50ax", "ex3301_t0"}:
+                router.sessionkey = None
+            _LOGGER.exception("Error communicating with Zyxel device at %s", host)
             raise UpdateFailed(f"Error communicating with router: {err}") from err
 
     coordinator = DataUpdateCoordinator(
@@ -73,10 +251,32 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     await coordinator.async_config_entry_first_refresh()
 
+    # Keep integration title/data aligned with detected model for existing
+    # host-based entries (e.g. "Zyxel 172.16.1.254" -> "EX3301-T0").
+    detected_model = _detected_model_from_data(entry, coordinator.data)
+    detected_title = detected_model
+    updated_data = dict(entry.data)
+    data_changed = updated_data.get("model") != detected_model
+    if data_changed:
+        updated_data["model"] = detected_model
+    if _should_update_title_to_model(entry, detected_title):
+        hass.config_entries.async_update_entry(
+            entry,
+            title=detected_title,
+            data=updated_data,
+        )
+    elif data_changed:
+        hass.config_entries.async_update_entry(entry, data=updated_data)
+
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = {
         "coordinator": coordinator,
         "router": router,
+        "device_type": device_type,
+        "wifi_signature": _ex3301_wifi_signature(coordinator.data)
+        if device_type == "ex3301_t0"
+        else None,
+        "wifi_reload_pending": False,
     }
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)

--- a/custom_components/ha_zyxel/backend.py
+++ b/custom_components/ha_zyxel/backend.py
@@ -1,0 +1,615 @@
+"""Shared Zyxel backend helpers."""
+from __future__ import annotations
+
+import ast
+import json
+import logging
+import re
+from base64 import b64decode, b64encode
+from collections.abc import Mapping
+from secrets import token_bytes
+
+import requests
+from cryptography.hazmat.primitives import hashes, padding
+from cryptography.hazmat.primitives.asymmetric import padding as asym_padding
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+from cryptography.hazmat.primitives.serialization import load_pem_public_key
+from requests.packages.urllib3.exceptions import InsecureRequestWarning
+from homeassistant.helpers.update_coordinator import UpdateFailed
+
+_LOGGER = logging.getLogger(__name__)
+requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
+_IP_LIKE_RE = re.compile(r"^\d{1,3}(?:\.\d{1,3}){3}$")
+_MODEL_LIKE_RE = re.compile(r"^[A-Z]{2,}\d[\w-]*$", re.IGNORECASE)
+_LANGUAGE_LIKE = {
+    "english",
+    "french",
+    "francais",
+    "german",
+    "deutsch",
+    "spanish",
+    "espanol",
+    "italian",
+    "portuguese",
+}
+
+
+class NWA50AXClient:
+    """Minimal Zyxel NWA50AX client using the zysh CGI endpoint."""
+
+    def __init__(self, host: str, username: str, password: str, timeout: int = 15) -> None:
+        self.host = host.rstrip("/")
+        self.username = username
+        self.password = password
+        self.timeout = timeout
+        self._session = requests.Session()
+        self._session.headers.update(
+            {
+                "User-Agent": "Mozilla/5.0",
+                "X-Requested-With": "XMLHttpRequest",
+                "Origin": self.host,
+                "Referer": f"{self.host}/",
+            }
+        )
+        self._session.verify = False
+
+    def login(self) -> None:
+        self._session = requests.Session()
+        self._session.headers.update(
+            {
+                "User-Agent": "Mozilla/5.0",
+                "X-Requested-With": "XMLHttpRequest",
+                "Origin": self.host,
+                "Referer": f"{self.host}/",
+            }
+        )
+        self._session.verify = False
+        page = self._session.get(f"{self.host}/", timeout=self.timeout)
+        _LOGGER.debug("NWA50AX login page status=%s url=%s", page.status_code, page.url)
+        if page.status_code >= 500:
+            _LOGGER.debug("NWA50AX login page returned %s; continuing to POST login", page.status_code)
+        csrf_token = (
+            self._session.cookies.get("CSRFToken")
+            or self._session.cookies.get("csrftok")
+            or self._session.cookies.get("csrf")
+        )
+        payloads = [
+            {"username": self.username, "pwd": self.password},
+            {"username": self.username, "password": self.password},
+        ]
+        if csrf_token:
+            for payload in payloads:
+                payload["CSRFToken"] = csrf_token
+
+        last_response = None
+        for payload in payloads:
+            resp = self._session.post(
+                f"{self.host}/",
+                data=payload,
+                timeout=self.timeout,
+                allow_redirects=True,
+            )
+            last_response = resp
+            if resp.status_code >= 500:
+                _LOGGER.debug(
+                    "NWA50AX login POST returned %s; checking body/cookies instead of failing hard",
+                    resp.status_code,
+                )
+            _LOGGER.debug("NWA50AX login response status=%s url=%s", resp.status_code, resp.url)
+            if "login" in resp.text.lower() and "fail" in resp.text.lower():
+                continue
+            if "invalid" in resp.text.lower() and "password" in resp.text.lower():
+                continue
+            if self._session.cookies.get("authtok") or self._session.cookies.get("authtoken") or self._session.cookies.get("auth"):
+                return
+
+        _LOGGER.debug("NWA50AX login cookies after POST attempts: %s", self._session.cookies.get_dict())
+        if last_response is not None and (
+            "login" in last_response.text.lower() and "fail" in last_response.text.lower()
+        ):
+            raise UpdateFailed("Login failed")
+        if last_response is not None and (
+            "invalid" in last_response.text.lower() and "password" in last_response.text.lower()
+        ):
+            raise UpdateFailed("Login failed")
+        raise UpdateFailed("Login session not established")
+
+    def _post_cmds(self, cmds: list[str]) -> dict:
+        from urllib.parse import quote_plus
+
+        payload = "&".join(["filter=js2"] + [f"cmd={quote_plus(cmd)}" for cmd in cmds] + ["write=0"])
+        resp = self._session.post(
+            f"{self.host}/cgi-bin/zysh-cgi",
+            data=payload,
+            headers={"Content-Type": "application/x-www-form-urlencoded; charset=UTF-8"},
+            timeout=self.timeout,
+        )
+        if resp.status_code >= 400:
+            _LOGGER.debug("NWA50AX zysh-cgi returned %s for %s", resp.status_code, cmds[0])
+        return self._parse_zysh_response(resp.text)
+
+    @staticmethod
+    def _parse_zysh_response(text: str) -> dict:
+        stripped = text.strip()
+        lowered = stripped.lower()
+        if "login" in lowered and ("password" in lowered or "invalid" in lowered):
+            raise UpdateFailed("Login failed")
+        if stripped.startswith("{") or stripped.startswith("["):
+            try:
+                parsed_json = json.loads(stripped)
+            except json.JSONDecodeError:
+                parsed_json = None
+            else:
+                if isinstance(parsed_json, dict):
+                    return parsed_json
+
+        result: dict = {}
+        pattern = re.compile(
+            r"var\s+([A-Za-z0-9_]+)\s*=\s*\[(.*?)\];\s*var\s+errno\1\s*=\s*(\d+);\s*var\s+errmsg\1\s*=\s*(['\"])(.*?)\4;?",
+            re.S,
+        )
+        for match in pattern.finditer(text):
+            data_name = match.group(1)
+            raw = match.group(2)
+            parsed = ast.literal_eval("[" + raw + "]")
+            errno = int(match.group(3))
+            errmsg = match.group(5)
+            if errno != 0:
+                raise UpdateFailed(errmsg or f"zysh-cgi command {data_name} failed with errno {errno}")
+            result[data_name] = parsed
+        if not result:
+            var_pattern = re.compile(r"var\s+([A-Za-z0-9_]+)\s*=\s*(\[[^\n;]*\]|'[^']*'|\"[^\"]*\"|\d+)\s*;")
+            for match in var_pattern.finditer(text):
+                name = match.group(1)
+                value = match.group(2)
+                if not name.startswith("zyshdata"):
+                    continue
+                try:
+                    result[name] = ast.literal_eval(value)
+                except (SyntaxError, ValueError):
+                    continue
+        if not result:
+            raise UpdateFailed(f"zysh-cgi returned no usable data: {text[:120]}")
+        return result
+
+    def get_status(self) -> dict:
+        data = self._post_cmds(
+            [
+                "show language setting",
+                "show users current",
+                "show version",
+                "show hybrid-mode",
+                "show manager vlan",
+                "show wlan all",
+                "show wireless-hal current channel",
+                "show wireless-hal statistic",
+                "show nebula ethernet status",
+                "show nebula internet status",
+                "show nebula cloud status",
+                "show nebula claim status",
+                "show netconf proxy status",
+                "show fqdn",
+                "show mac",
+                "show serial-number",
+                "show netconf status",
+                "show nebula ntp status",
+                "show nebula cloud-gui status",
+            ]
+        )
+        normalized = normalize_zysh_status(data)
+        if not normalized:
+            raise UpdateFailed("zysh-cgi returned an empty status payload")
+        return normalized
+
+    @staticmethod
+    def get_device_name(status: Mapping) -> str | None:
+        """Return the best device name we can find in zysh status data."""
+        def _search(node: Mapping | list | str | object, preferred: tuple[str, ...]) -> str | None:
+            if isinstance(node, str):
+                candidate = node.strip()
+                if not candidate:
+                    return None
+                lowered = candidate.lower()
+                if lowered.startswith(("http://", "https://")):
+                    return None
+                if _IP_LIKE_RE.match(candidate):
+                    return None
+                if lowered in _LANGUAGE_LIKE:
+                    return None
+                return candidate
+            if isinstance(node, Mapping):
+                for key, value in node.items():
+                    key_lower = key.lower() if isinstance(key, str) else ""
+                    if any(token in key_lower for token in preferred):
+                        if isinstance(value, str) and value.strip():
+                            candidate = value.strip()
+                            lowered = candidate.lower()
+                            if (
+                                not _IP_LIKE_RE.match(candidate)
+                                and not lowered.startswith(("http://", "https://"))
+                                and lowered not in _LANGUAGE_LIKE
+                            ):
+                                return candidate
+                    nested = _search(value, preferred)
+                    if nested:
+                        return nested
+            if isinstance(node, list):
+                for item in node:
+                    nested = _search(item, preferred)
+                    if nested:
+                        return nested
+            return None
+
+        name = _search(status, ("system name", "system_name"))
+        if name:
+            return name
+        name = _search(status, ("fqdn", "hostname", "device_name"))
+        if name:
+            return name
+        return None
+
+    @staticmethod
+    def get_device_model(status: Mapping) -> str | None:
+        """Return a model-like identifier from zysh status data."""
+        def _search(node: Mapping | list | str | object) -> str | None:
+            if isinstance(node, str):
+                candidate = node.strip()
+                if not candidate:
+                    return None
+                lowered = candidate.lower()
+                if lowered in _LANGUAGE_LIKE or _IP_LIKE_RE.match(candidate):
+                    return None
+                return candidate if _MODEL_LIKE_RE.match(candidate) else None
+            if isinstance(node, Mapping):
+                for key, value in node.items():
+                    key_lower = key.lower() if isinstance(key, str) else ""
+                    if any(token in key_lower for token in ("model", "product", "platform", "hardware")):
+                        found = _search(value)
+                        if found:
+                            return found
+                for value in node.values():
+                    found = _search(value)
+                    if found:
+                        return found
+            if isinstance(node, list):
+                for item in node:
+                    found = _search(item)
+                    if found:
+                        return found
+            return None
+
+        return _search(status)
+
+    def reboot(self) -> None:
+        self._post_cmds(["reboot"])
+
+
+class EX3301T0Client:
+    """Probe Zyxel EX3301-T0 stock firmware CGI endpoints."""
+
+    # Endpoints tried without any path prefix (same level as login/key endpoints).
+    # UserLoginCheck intentionally excluded — it consistently times out on this firmware.
+    _ENDPOINTS = (
+        "loginAccountLevel",
+        "MenuList",
+        "CardInfo",
+    )
+    # Endpoints that may live under cgi-bin/ on some firmware builds.
+    # lanhosts intentionally excluded — it creates one entry per client device.
+    _CGI_ENDPOINTS = (
+        "DAL?oid=cardpage_status",
+        "DAL?oid=lan",
+        "DAL?oid=wlan",
+    )
+    # Validation succeeds if ANY of these return data.
+    _CORE_ENDPOINTS = frozenset({
+        "MenuList",
+        "CardInfo",
+        "UserLoginCheck",
+        "DAL?oid=lan",
+        "cgi-bin/DAL?oid=lan",
+    })
+
+    def __init__(self, host: str, username: str, password: str, timeout: int = 15) -> None:
+        self.host = host.rstrip("/")
+        self.username = username
+        self.password = password
+        self.timeout = timeout
+        self._session = requests.Session()
+        self._session.headers.update(
+            {
+                "User-Agent": "Mozilla/5.0",
+                "X-Requested-With": "XMLHttpRequest",
+                "Origin": self.host,
+                "Referer": f"{self.host}/",
+            }
+        )
+        self._session.verify = False
+        self._aes_key: bytes | None = None
+        self._csrf_token: str | None = None
+
+    @staticmethod
+    def _aes_encrypt(plaintext: str, key: bytes, iv: bytes) -> str:
+        padder = padding.PKCS7(128).padder()
+        padded = padder.update(plaintext.encode("utf-8")) + padder.finalize()
+        cipher = Cipher(algorithms.AES(key), modes.CBC(iv[:16]))
+        encryptor = cipher.encryptor()
+        ciphertext = encryptor.update(padded) + encryptor.finalize()
+        return b64encode(ciphertext).decode("ascii")
+
+    @staticmethod
+    def _aes_decrypt(ciphertext_b64: str, key: bytes, iv_b64: str) -> str:
+        iv = b64decode(iv_b64)
+        cipher = Cipher(algorithms.AES(key), modes.CBC(iv[:16]))
+        decryptor = cipher.decryptor()
+        plaintext = decryptor.update(b64decode(ciphertext_b64)) + decryptor.finalize()
+        unpadder = padding.PKCS7(128).unpadder()
+        return (unpadder.update(plaintext) + unpadder.finalize()).decode("utf-8")
+
+    def _encrypt_login_payload(self, public_key_pem: str) -> dict[str, str]:
+        aes_key_raw = token_bytes(32)
+        aes_key_b64 = b64encode(aes_key_raw).decode("ascii")
+        iv_raw = token_bytes(32)
+        iv_b64 = b64encode(iv_raw).decode("ascii")
+        self._aes_key = aes_key_raw
+        payload = {
+            "Input_Account": self.username,
+            "Input_Passwd": b64encode(self.password.encode("utf-8")).decode("ascii"),
+            "currLang": "en",
+            "RememberPassword": 0,
+            "SHA512_password": False,
+        }
+        encrypted = self._aes_encrypt(json.dumps(payload, separators=(",", ":")), aes_key_raw, iv_raw)
+        public_key = load_pem_public_key(public_key_pem.encode("utf-8"))
+        encrypted_key = public_key.encrypt(
+            aes_key_b64.encode("utf-8"),
+            asym_padding.PKCS1v15(),
+        )
+        return {
+            "content": encrypted,
+            "key": b64encode(encrypted_key).decode("ascii"),
+            "iv": iv_b64,
+        }
+
+    def _post_login(self, login_payload: dict[str, str], raw_json_string: bool = False) -> requests.Response:
+        if raw_json_string:
+            return self._session.post(
+                f"{self.host}/UserLogin",
+                data=json.dumps(login_payload),
+                timeout=self.timeout,
+                allow_redirects=False,
+            )
+        return self._session.post(
+            f"{self.host}/UserLogin",
+            data=login_payload,
+            timeout=self.timeout,
+            allow_redirects=False,
+        )
+
+    def login(self) -> None:
+        self._session = requests.Session()
+        self._session.headers.update(
+            {
+                "User-Agent": "Mozilla/5.0",
+                "X-Requested-With": "XMLHttpRequest",
+                "Origin": self.host,
+                "Referer": f"{self.host}/",
+            }
+        )
+        self._session.verify = False
+        try:
+            page = self._session.get(f"{self.host}/", timeout=self.timeout, allow_redirects=False)
+            _LOGGER.debug("EX3301-T0 login page status=%s url=%s", page.status_code, page.url)
+            if page.status_code in (301, 302, 303, 307, 308):
+                location = page.headers.get("Location", "")
+                _LOGGER.debug("EX3301-T0 login page redirected to %s", location)
+                if location.startswith("https://"):
+                    raise UpdateFailed("EX3301-T0 redirected to HTTPS during login bootstrap")
+        except requests.exceptions.ReadTimeout:
+            _LOGGER.debug("EX3301-T0 initial page fetch timed out; proceeding to RSA key fetch")
+        except requests.exceptions.RequestException as err:
+            _LOGGER.debug("EX3301-T0 initial page fetch failed (%s); proceeding to RSA key fetch", err)
+
+        key_resp = self._session.get(
+            f"{self.host}/getRSAPublickKey",
+            timeout=self.timeout,
+            allow_redirects=False,
+        )
+        key_data = self._safe_json(key_resp, "EX3301-T0 RSA key request")
+        public_key = key_data["RSAPublicKey"]
+        login_payload = self._encrypt_login_payload(public_key)
+        resp = self._post_login(login_payload, raw_json_string=True)
+        _LOGGER.debug("EX3301-T0 login status=%s url=%s", resp.status_code, resp.url)
+        if resp.status_code == 401 and "Decrypt Fail" in resp.text:
+            _LOGGER.debug("EX3301-T0 login decrypt failed with raw JSON payload; retrying as form")
+            resp = self._post_login(login_payload, raw_json_string=False)
+            _LOGGER.debug("EX3301-T0 login retry status=%s url=%s", resp.status_code, resp.url)
+        if resp.status_code in (301, 302, 303, 307, 308):
+            location = resp.headers.get("Location", "")
+            _LOGGER.debug("EX3301-T0 login redirected to %s", location)
+            if location.startswith("https://"):
+                raise UpdateFailed("EX3301-T0 redirected to HTTPS during login")
+        elif not resp.ok:
+            snippet = resp.text.strip().replace("\n", " ")[:160]
+            raise UpdateFailed(f"EX3301-T0 login returned {resp.status_code}: {snippet}")
+        body = self._safe_json(resp, "EX3301-T0 login")
+        if "content" in body and "iv" in body:
+            if not self._aes_key:
+                raise UpdateFailed("EX3301-T0 missing AES session key")
+            decrypted = self._aes_decrypt(body["content"], self._aes_key, body["iv"])
+            data = json.loads(decrypted)
+        else:
+            data = body
+        session_key = (
+            data.get("sessionkey")
+            or data.get("sessionKey")
+            or resp.cookies.get("zySessionKey")
+            or resp.cookies.get("sessionkey")
+            or resp.cookies.get("sessionKey")
+            or self._session.cookies.get("zySessionKey")
+        )
+        if session_key:
+            self._csrf_token = session_key
+            self._session.headers.update({"CSRFToken": session_key})
+            self._session.cookies.set("zySessionKey", session_key, path="/")
+        if not session_key and not any(k in data for k in ("loginAccount", "loginLevel", "quickStart", "ThemeColor")):
+            raise UpdateFailed("Login session not established")
+        self._probe("UserLoginCheck")
+
+    def _request(self, endpoint: str, method: str = "get") -> requests.Response:
+        url = f"{self.host}/{endpoint}"
+        request = getattr(self._session, method.lower())
+        headers = {}
+        if method.lower() in {"post", "put", "delete"} and self._csrf_token:
+            headers["CSRFToken"] = self._csrf_token
+        response = request(url, timeout=self.timeout, allow_redirects=False, headers=headers)
+        if response.status_code in (301, 302, 303, 307, 308):
+            location = response.headers.get("Location", "")
+            _LOGGER.debug("EX3301-T0 request %s redirected to %s", endpoint, location)
+            if location.startswith("https://"):
+                raise UpdateFailed(f"EX3301-T0 redirected to HTTPS while requesting {endpoint}")
+        return response
+
+    _SESSION_EXPIRED_MARKERS = ("login", "Login", "unauthorized", "Unauthorized", "sessionExpired")
+
+    def _is_session_expired(self, resp: requests.Response) -> bool:
+        """Return True if the response looks like a session-expired redirect or error."""
+        if resp.status_code in (301, 302, 303, 307, 308):
+            location = resp.headers.get("Location", "")
+            return any(m in location for m in ("login", "Login"))
+        if resp.status_code in (401, 403):
+            return True
+        return False
+
+    def _probe(self, endpoint: str) -> dict | str | None:
+        try:
+            resp = self._request(endpoint)
+        except requests.exceptions.ReadTimeout:
+            _LOGGER.warning("EX3301-T0 probe timed out for %s on %s", endpoint, self.host)
+            return None
+        except requests.exceptions.RequestException as err:
+            _LOGGER.warning(
+                "EX3301-T0 probe request failed for %s on %s: %s",
+                endpoint,
+                self.host,
+                err,
+            )
+            return None
+        _LOGGER.debug(
+            "EX3301-T0 probe %s status=%s body_prefix=%r",
+            endpoint,
+            resp.status_code,
+            resp.text[:120],
+        )
+        if self._is_session_expired(resp):
+            raise UpdateFailed(f"EX3301-T0 session expired (probe {endpoint})")
+        text = resp.text.strip()
+        if not text:
+            return None
+        try:
+            parsed = json.loads(text)
+        except json.JSONDecodeError:
+            return text
+        # Decrypt AES-wrapped responses using the session key from login.
+        if isinstance(parsed, dict) and "content" in parsed and "iv" in parsed and self._aes_key:
+            try:
+                decrypted = self._aes_decrypt(parsed["content"], self._aes_key, parsed["iv"])
+                return json.loads(decrypted)
+            except Exception as err:  # pylint: disable=broad-except
+                _LOGGER.debug("EX3301-T0 probe %s decrypt failed: %s", endpoint, err)
+        return parsed
+
+    @staticmethod
+    def _safe_json(resp: requests.Response, context: str) -> dict:
+        try:
+            body = resp.json()
+        except ValueError as err:
+            snippet = resp.text.strip().replace("\n", " ")
+            raise UpdateFailed(f"{context} returned non-JSON response: {snippet[:120]}") from err
+        if not isinstance(body, dict):
+            raise UpdateFailed(f"{context} returned an unexpected response shape")
+        return body
+
+    @staticmethod
+    def _extract_jsonish_blob(blob: str) -> dict | list | str | None:
+        blob = blob.strip()
+        if not blob:
+            return None
+        for candidate in (blob, blob.replace("\r", "")):
+            try:
+                return json.loads(candidate)
+            except json.JSONDecodeError:
+                continue
+        if blob.startswith("base64:"):
+            try:
+                decoded = b64decode(blob.removeprefix("base64:")).decode("utf-8", "ignore")
+                return json.loads(decoded)
+            except Exception:  # pylint: disable=broad-except
+                return blob
+        return blob
+
+    def get_status(self) -> dict:
+        data: dict[str, object] = {}
+        has_core_payload = False
+        for endpoint in self._ENDPOINTS:
+            payload = self._probe(endpoint)
+            if payload is not None:
+                data[endpoint] = payload
+                if endpoint in self._CORE_ENDPOINTS:
+                    has_core_payload = True
+        # Try DAL endpoints both with and without cgi-bin/ prefix.
+        for endpoint in self._CGI_ENDPOINTS:
+            payload = self._probe(endpoint)
+            if payload is not None:
+                data[endpoint] = payload
+                if endpoint in self._CORE_ENDPOINTS:
+                    has_core_payload = True
+            else:
+                cgi_endpoint = f"cgi-bin/{endpoint}"
+                payload = self._probe(cgi_endpoint)
+                if payload is not None:
+                    data[endpoint] = payload
+                    if cgi_endpoint in self._CORE_ENDPOINTS:
+                        has_core_payload = True
+        if not has_core_payload:
+            raise UpdateFailed("EX3301-T0 returned no usable core CGI payloads")
+        return data
+
+    def get_device_name(self, status: Mapping) -> str | None:
+        for key in ("MenuList", "CardInfo", "DAL?oid=cardpage_status", "DAL?oid=lan"):
+            value = status.get(key)
+            if isinstance(value, Mapping):
+                for candidate_key in ("systemName", "SystemName", "host_name", "hostname", "device_name"):
+                    candidate = value.get(candidate_key)
+                    if isinstance(candidate, str) and candidate.strip():
+                        return candidate.strip()
+        return None
+
+    def get_device_model(self, status: Mapping) -> str | None:
+        for key in ("CardInfo", "MenuList", "DAL?oid=lan"):
+            value = status.get(key)
+            if isinstance(value, Mapping):
+                for candidate_key in ("model", "Model", "model_name", "device_model"):
+                    candidate = value.get(candidate_key)
+                    if isinstance(candidate, str) and candidate.strip():
+                        return candidate.strip()
+        return None
+
+    def reboot(self) -> None:
+        self._request("UserLoginCheck")
+
+
+def normalize_zysh_status(data: Mapping) -> dict:
+    """Flatten the zysh response into a status dict."""
+    normalized: dict = {}
+    for key, value in data.items():
+        if isinstance(key, str) and isinstance(value, list) and value:
+            item = value[0]
+            if isinstance(item, dict):
+                normalized[key] = item
+                for subkey, subvalue in item.items():
+                    if subkey.startswith("_"):
+                        normalized[subkey.lstrip("_")] = subvalue
+            else:
+                normalized[key] = value
+    return normalized

--- a/custom_components/ha_zyxel/button.py
+++ b/custom_components/ha_zyxel/button.py
@@ -7,9 +7,89 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers import entity_registry as er
 from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
+_LANGUAGE_LIKE_VALUES = {"english", "french", "francais", "german", "deutsch", "spanish", "espanol"}
+
+
+def _looks_like_ip(value: str) -> bool:
+    parts = value.split(".")
+    if len(parts) != 4:
+        return False
+    try:
+        return all(0 <= int(p) <= 255 for p in parts)
+    except ValueError:
+        return False
+
+
+def _button_device_model(entry: ConfigEntry, coordinator) -> tuple[str, str | None]:
+    """Return (model_name, sw_version) from coordinator data or entry config."""
+    data = coordinator.data if coordinator else None
+    if data:
+        # coordinator data is a nested dict; find leaf values by key suffix.
+        def _find(d, key):
+            if isinstance(d, dict):
+                for k, v in d.items():
+                    if k == key and not isinstance(v, (dict, list)):
+                        return v
+                    found = _find(v, key)
+                    if found is not None:
+                        return found
+            elif isinstance(d, list):
+                for item in d:
+                    found = _find(item, key)
+                    if found is not None:
+                        return found
+            return None
+
+        model = (
+            _find(data, "ModelName")
+            or _find(data, "ProductClass")
+            or _find(data, "HardwareVersion")
+        )
+        sw_version = _find(data, "SoftwareVersion") or _find(data, "FirmwareVersion")
+    else:
+        model = None
+        sw_version = None
+
+    if not model:
+        model = entry.data.get("device_type", "").upper().replace("_", "-") or entry.data.get("host", "")
+
+    return model, sw_version
+
+
+def _button_system_name(coordinator) -> str | None:
+    data = coordinator.data if coordinator else None
+    if not data:
+        return None
+
+    def _search(d):
+        if isinstance(d, dict):
+            for k, v in d.items():
+                key_lower = str(k).lower()
+                if isinstance(v, str):
+                    candidate = v.strip()
+                    lowered = candidate.lower()
+                    if (
+                        candidate
+                        and not _looks_like_ip(candidate)
+                        and lowered not in _LANGUAGE_LIKE_VALUES
+                        and any(t in key_lower for t in ("system name", "system_name", "hostname", "fqdn", "device_name"))
+                    ):
+                        return candidate
+                found = _search(v)
+                if found:
+                    return found
+        elif isinstance(d, list):
+            for item in d:
+                found = _search(item)
+                if found:
+                    return found
+        return None
+
+    return _search(data)
 
 
 async def async_setup_entry(
@@ -17,24 +97,39 @@ async def async_setup_entry(
 ) -> None:
     """Set up the Zyxel buttons."""
     router = hass.data[DOMAIN][entry.entry_id]["router"]
-    async_add_entities([ZyxelRebootButton(entry, router)])
+    coordinator = hass.data[DOMAIN][entry.entry_id].get("coordinator")
+    ent_reg = er.async_get(hass)
+    for reg_entry in list(er.async_entries_for_config_entry(ent_reg, entry.entry_id)):
+        if reg_entry.entity_id.startswith("button.zyxel_"):
+            _LOGGER.debug("Removing legacy prefixed button for rename migration: %s", reg_entry.entity_id)
+            ent_reg.async_remove(reg_entry.entity_id)
+    async_add_entities([ZyxelRebootButton(entry, router, coordinator)])
 
 
 class ZyxelRebootButton(ButtonEntity):
     """Representation of a Zyxel reboot button."""
 
-    def __init__(self, entry: ConfigEntry, router) -> None:
+    _attr_has_entity_name = True
+
+    def __init__(self, entry: ConfigEntry, router, coordinator) -> None:
         """Initialize the button."""
         self._router = router
         self._attr_unique_id = f"{entry.entry_id}_reboot"
+        model, sw_version = _button_device_model(entry, coordinator)
+        host = str(entry.data.get("host", "")).replace("http://", "").replace("https://", "")
+        host = host.split("/", 1)[0]
+        display_name = _button_system_name(coordinator) or (
+            f"Zyxel {host}" if host else f"Zyxel {model}"
+        )
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, entry.entry_id)},
-            name=f"Zyxel ({entry.data['host']})",
+            name=display_name,
             manufacturer="Zyxel",
-            model="",
+            model=model,
+            sw_version=sw_version,
         )
         self._attr_icon = "mdi:restart"
-        self._attr_name = "Zyxel Reboot Device"
+        self._attr_name = "[Action] Reboot Device"
 
     async def async_press(self) -> None:
         """Handle the button press."""

--- a/custom_components/ha_zyxel/config_flow.py
+++ b/custom_components/ha_zyxel/config_flow.py
@@ -1,26 +1,101 @@
 """Config flow for Zyxel integration."""
 import logging
+import re
 
 import voluptuous as vol
-
-from homeassistant import config_entries, core
+import requests
+from homeassistant import config_entries, core, exceptions
+from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
+from homeassistant.helpers.selector import SelectSelector, SelectSelectorConfig, SelectSelectorMode
+from homeassistant.helpers.update_coordinator import UpdateFailed
 
-from .api import (
+from custom_components.ha_zyxel.api import (
     ZyxelAuthenticationError,
     ZyxelConnectionError,
     create_router,
     fetch_status,
 )
-from .const import DEFAULT_HOST, DEFAULT_USERNAME, DOMAIN
+from custom_components.ha_zyxel.backend import EX3301T0Client, NWA50AXClient
+from .const import (
+    CONF_DEVICE_TYPE,
+    DEFAULT_DEVICE_TYPE,
+    DEFAULT_HOST,
+    DEFAULT_NAME,
+    DEFAULT_USERNAME,
+    DOMAIN,
+)
 
 _LOGGER = logging.getLogger(__name__)
-
-# Block excessive nr7101 debug logging
 nr7101_logger = logging.getLogger("nr7101.nr7101")
 nr7101_logger.setLevel(logging.WARNING)
 
-DATA_SCHEMA = vol.Schema(
+LEGACY_DEVICE_TYPES = {
+    "ax7501-b0",
+    "fwa505",
+    "fwa510",
+    "fwa710-5g-v2",
+    "lte3202-m437",
+    "lte7490-m904",
+    "lte5398-m904",
+    "nr5103e",
+    "nr5103v2",
+    "nr5307",
+    "nr7101",
+    "nr7102",
+    "nr7302",
+    "vmg3625-t50b",
+    "vmg4005-b50a",
+    "vmg8825-t50",
+}
+
+DEVICE_CHOICES = [
+    {"value": "generic", "label": "Generic Zyxel Device"},
+    {"value": "ax7501-b0", "label": "AX7501-B0"},
+    {"value": "fwa505", "label": "FWA505"},
+    {"value": "fwa510", "label": "FWA510"},
+    {"value": "fwa710-5g-v2", "label": "FWA710 5G V2"},
+    {"value": "lte3202-m437", "label": "LTE3202-M437"},
+    {"value": "lte7490-m904", "label": "LTE7490-M904"},
+    {"value": "lte5398-m904", "label": "LTE5398-M904"},
+    {"value": "nr5103e", "label": "NR5103E"},
+    {"value": "nr5103v2", "label": "NR5103v2"},
+    {"value": "nr5307", "label": "NR5307"},
+    {"value": "nr7101", "label": "NR7101"},
+    {"value": "nr7102", "label": "NR7102"},
+    {"value": "nr7302", "label": "NR7302"},
+    {"value": "nwa50ax", "label": "NWA50AX AP"},
+    {"value": "ex3301_t0", "label": "EX3301-T0 Router"},
+    {"value": "vmg3625-t50b", "label": "VMG3625-T50B"},
+    {"value": "vmg4005-b50a", "label": "VMG4005-B50A"},
+    {"value": "vmg8825-t50", "label": "VMG8825-T50"},
+]
+
+SELECT_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_DEVICE_TYPE, default=DEFAULT_DEVICE_TYPE): SelectSelector(
+            SelectSelectorConfig(options=DEVICE_CHOICES, mode=SelectSelectorMode.LIST)
+        )
+    }
+)
+
+NWA50AX_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_HOST): str,
+        vol.Required(CONF_USERNAME, default=DEFAULT_USERNAME): str,
+        vol.Required(CONF_PASSWORD): str,
+    }
+)
+
+EX3301T0_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_HOST, default=""): str,
+        vol.Required(CONF_USERNAME, default=DEFAULT_USERNAME): str,
+        vol.Required(CONF_PASSWORD): str,
+    }
+)
+
+LEGACY_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_HOST, default=DEFAULT_HOST): str,
         vol.Required(CONF_USERNAME, default=DEFAULT_USERNAME): str,
@@ -29,73 +104,245 @@ DATA_SCHEMA = vol.Schema(
 )
 
 
-async def validate_input(hass: core.HomeAssistant, data):
-    """Validate that the user input allows us to connect."""
+def _normalize_host(host: str) -> str:
+    if host.startswith("http://"):
+        return host.removeprefix("http://")
+    if host.startswith("https://"):
+        return host.removeprefix("https://")
+    return host
 
-    try:
-        # Create router instance and test connection
-        router = await hass.async_add_executor_job(
-            create_router,
-            data[CONF_HOST],
-            data[CONF_USERNAME],
-            data[CONF_PASSWORD]
-        )
 
-        await hass.async_add_executor_job(fetch_status, router)
-    except (ZyxelAuthenticationError, ZyxelConnectionError):
-        raise
-    except Exception as ex:
-        _LOGGER.error("Unable to connect to Zyxel device: %s", ex)
-        raise ZyxelConnectionError from ex
+def _safe_error_message(err: Exception) -> str:
+    message = str(err).strip()
+    return message or err.__class__.__name__
 
-    return {"title": f"Zyxel device: ({data[CONF_HOST]})"}
+
+def _is_connection_refused(err: Exception) -> bool:
+    if isinstance(err, requests.exceptions.ConnectionError):
+        cause = err.__cause__ or err.__context__
+        if isinstance(cause, ConnectionRefusedError):
+            return True
+    message = _safe_error_message(err).lower()
+    return (
+        "connection refused" in message
+        or "failed to establish a new connection" in message
+        or "max retries exceeded" in message
+    )
+
+
+def _discovery_host(discovery_info) -> str | None:
+    for attr in ("ssdp_location", "host", "ip_address", "address", "location"):
+        value = getattr(discovery_info, attr, None)
+        if isinstance(value, str) and value:
+            return _normalize_host(value.split("://", 1)[-1].split("/", 1)[0])
+    if isinstance(discovery_info, dict):
+        for key in ("ssdp_location", "host", "ip_address", "address", "location"):
+            value = discovery_info.get(key)
+            if isinstance(value, str) and value:
+                return _normalize_host(value.split("://", 1)[-1].split("/", 1)[0])
+    return None
+
+
+def _try_candidates(host: str, device_type: str) -> list[str]:
+    if device_type == "nwa50ax":
+        return [f"http://{host}", f"https://{host}"]
+    if device_type == "ex3301_t0":
+        return [f"http://{host}"]
+    if host.startswith("http://") or host.startswith("https://"):
+        return [host]
+    return [f"http://{host}", f"https://{host}"]
+
+
+def _split_hosts(raw_hosts: str) -> list[str]:
+    hosts = [part.strip() for part in re.split(r"[\n,]+", raw_hosts or "") if part.strip()]
+    return list(dict.fromkeys(hosts))
+
+
+async def _validate_connection(hass: core.HomeAssistant, data):
+    device_type = data[CONF_DEVICE_TYPE]
+    host = _normalize_host(data[CONF_HOST])
+
+    _LOGGER.debug("Validating Zyxel connection to %s as %s (%s)", host, data[CONF_USERNAME], device_type)
+
+    last_error = None
+    for candidate in _try_candidates(host, device_type):
+        _LOGGER.debug("Trying Zyxel connection candidate %s", candidate)
+        try:
+            if device_type == "nwa50ax":
+                router = NWA50AXClient(candidate, data[CONF_USERNAME], data[CONF_PASSWORD])
+                await hass.async_add_executor_job(router.login)
+                status = await hass.async_add_executor_job(router.get_status)
+                if not status:
+                    raise UpdateFailed("zysh-cgi returned an empty status payload")
+                device_model = await hass.async_add_executor_job(router.get_device_model, status)
+                device_name = await hass.async_add_executor_job(router.get_device_name, status)
+                device_name = device_model or device_name
+            elif device_type == "ex3301_t0":
+                router = EX3301T0Client(candidate, data[CONF_USERNAME], data[CONF_PASSWORD])
+                await hass.async_add_executor_job(router.login)
+                status = {}
+                try:
+                    status = await hass.async_add_executor_job(router.get_status)
+                except Exception as ex:  # pylint: disable=broad-except
+                    _LOGGER.warning(
+                        "EX3301-T0 status probes failed during setup for %s: %s; accepting login-only validation",
+                        host,
+                        _safe_error_message(ex),
+                    )
+                if status:
+                    device_name = await hass.async_add_executor_job(router.get_device_name, status)
+                else:
+                    device_name = None
+            else:
+                router = await hass.async_add_executor_job(
+                    create_router,
+                    candidate,
+                    data[CONF_USERNAME],
+                    data[CONF_PASSWORD],
+                )
+                await hass.async_add_executor_job(fetch_status, router)
+                device_name = None
+
+            data[CONF_HOST] = host if device_type in {"nwa50ax", "ex3301_t0"} else candidate
+            title = device_name or (
+                host if device_type in {"nwa50ax", "ex3301_t0"} else DEFAULT_NAME
+            )
+            return {"title": title}
+        except UpdateFailed as ex:
+            last_error = ex
+            _LOGGER.debug("Candidate %s returned empty data: %s", candidate, _safe_error_message(ex))
+        except ZyxelAuthenticationError as ex:
+            raise ConfigEntryAuthFailed from ex
+        except ZyxelConnectionError as ex:
+            last_error = ex
+            _LOGGER.debug("Candidate %s failed: %s", candidate, _safe_error_message(ex))
+        except Exception as ex:  # pylint: disable=broad-except
+            last_error = ex
+            error_message = _safe_error_message(ex).lower()
+            if "auth" in error_message or "login failed" in error_message:
+                raise ConfigEntryAuthFailed from ex
+            if _is_connection_refused(ex):
+                _LOGGER.debug("Candidate %s refused connection; trying next option", candidate)
+                continue
+            _LOGGER.debug("Candidate %s failed: %s", candidate, _safe_error_message(ex))
+
+    raise last_error if last_error else Exception("Connection failed")
 
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
-    """Handle a config flow for Zyxel devices."""
-
     VERSION = 1
     CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
 
     async def async_step_user(self, user_input=None):
-        """Handle the initial step."""
-        errors = {}
-        success = False
-
         if user_input is not None:
-            host = user_input[CONF_HOST]
+            self._device_type = user_input[CONF_DEVICE_TYPE]
+            if self._device_type == "nwa50ax":
+                return await self.async_step_nwa50ax()
+            if self._device_type == "ex3301_t0":
+                return await self.async_step_ex3301_t0()
+            return await self.async_step_legacy()
+        return self.async_show_form(step_id="user", data_schema=SELECT_SCHEMA)
 
-            # sanitize entry
-            if not host.startswith("http://") and not host.startswith("https://"):
-                host = f"https://{host}"
-                user_input[CONF_HOST] = host
-
-            try:
-                info = await validate_input(self.hass, user_input)
-                success = True
-            except ZyxelAuthenticationError:
-                errors["base"] = "invalid_auth"
-            except ZyxelConnectionError as err:
-                _LOGGER.error("Connection attempt failed: %s", err)
+    async def async_step_nwa50ax(self, user_input=None):
+        errors = {}
+        if user_input is not None:
+            hosts = _split_hosts(user_input[CONF_HOST])
+            if not hosts:
                 errors["base"] = "cannot_connect"
+                return self.async_show_form(step_id="nwa50ax", data_schema=NWA50AX_SCHEMA, errors=errors)
+            data = {
+                CONF_DEVICE_TYPE: "nwa50ax",
+                CONF_HOST: hosts[0],
+                CONF_USERNAME: user_input[CONF_USERNAME],
+                CONF_PASSWORD: user_input[CONF_PASSWORD],
+            }
+            try:
+                info = await _validate_connection(self.hass, data)
+                self._validated_data = data
+                self._validated_info = info
+                await self.async_set_unique_id(data[CONF_HOST])
+                self._abort_if_unique_id_configured()
+                if len(hosts) > 1:
+                    for host in hosts[1:]:
+                        await self.hass.config_entries.flow.async_init(
+                            DOMAIN,
+                            context={"source": "import"},
+                            data={
+                                CONF_DEVICE_TYPE: "nwa50ax",
+                                CONF_HOST: host,
+                                CONF_USERNAME: user_input[CONF_USERNAME],
+                                CONF_PASSWORD: user_input[CONF_PASSWORD],
+                            },
+                        )
+                return self.async_create_entry(title=info["title"], data=data)
+            except ConfigEntryAuthFailed:
+                errors["base"] = "invalid_auth"
+            except Exception:  # pylint: disable=broad-except
+                _LOGGER.exception("NWA50AX validation failed for %s", hosts[0])
+                errors["base"] = "cannot_connect"
+        return self.async_show_form(step_id="nwa50ax", data_schema=NWA50AX_SCHEMA, errors=errors)
 
-            if not success and "https" not in user_input["host"]:
-                _LOGGER.info("User specified http but it failed, trying https...")
-                user_input["host"] = user_input["host"].replace("http://", "https://")
-                try:
-                    info = await validate_input(self.hass, user_input)
-                    success = True
-                except ZyxelAuthenticationError:
-                    errors["base"] = "invalid_auth"
-                except ZyxelConnectionError:
-                    errors["base"] = "cannot_connect"
-                except Exception as e:  # pylint: disable=broad-except
-                    _LOGGER.exception("Second attempt failed: %s", e)
-                    errors["base"] = "unknown"
+    async def async_step_ex3301_t0(self, user_input=None):
+        errors = {}
+        if user_input is not None:
+            data = {
+                CONF_DEVICE_TYPE: "ex3301_t0",
+                CONF_HOST: user_input[CONF_HOST],
+                CONF_USERNAME: user_input[CONF_USERNAME],
+                CONF_PASSWORD: user_input[CONF_PASSWORD],
+            }
+            try:
+                info = await _validate_connection(self.hass, data)
+                return self.async_create_entry(title=info["title"], data=data)
+            except ConfigEntryAuthFailed:
+                errors["base"] = "invalid_auth"
+            except UpdateFailed:
+                _LOGGER.exception("EX3301-T0 validation failed for %s", user_input[CONF_HOST])
+                errors["base"] = "cannot_connect"
+            except Exception as ex:  # pylint: disable=broad-except
+                if _is_connection_refused(ex):
+                    _LOGGER.warning("EX3301-T0 connection refused for %s", user_input[CONF_HOST])
+                else:
+                    _LOGGER.exception("EX3301-T0 validation failed for %s", user_input[CONF_HOST])
+                errors["base"] = "cannot_connect"
+        return self.async_show_form(step_id="ex3301_t0", data_schema=EX3301T0_SCHEMA, errors=errors)
 
-        if success:
+    async def async_step_legacy(self, user_input=None):
+        errors = {}
+        if user_input is not None:
+            data = {
+                CONF_DEVICE_TYPE: getattr(self, "_device_type", "legacy"),
+                CONF_HOST: user_input[CONF_HOST],
+                CONF_USERNAME: user_input[CONF_USERNAME],
+                CONF_PASSWORD: user_input[CONF_PASSWORD],
+            }
+            try:
+                info = await _validate_connection(self.hass, data)
+                return self.async_create_entry(title=info["title"], data=data)
+            except ConfigEntryAuthFailed:
+                errors["base"] = "invalid_auth"
+            except Exception as ex:  # pylint: disable=broad-except
+                if _is_connection_refused(ex):
+                    _LOGGER.debug("Legacy connection refused for %s", user_input[CONF_HOST])
+                else:
+                    _LOGGER.exception("Legacy validation failed for %s", user_input[CONF_HOST])
+                errors["base"] = "cannot_connect"
+        return self.async_show_form(step_id="legacy", data_schema=LEGACY_SCHEMA, errors=errors)
+
+    async def async_step_import(self, user_input=None):
+        if not user_input or user_input.get(CONF_DEVICE_TYPE) != "nwa50ax":
+            return self.async_abort(reason="not_supported")
+        try:
+            await self.async_set_unique_id(user_input[CONF_HOST])
+            self._abort_if_unique_id_configured()
+            info = await _validate_connection(self.hass, user_input)
             return self.async_create_entry(title=info["title"], data=user_input)
-        else:
-            return self.async_show_form(
-                step_id="user", data_schema=DATA_SCHEMA, errors=errors
-            )
+        except ConfigEntryAuthFailed:
+            return self.async_abort(reason="invalid_auth")
+        except Exception:  # pylint: disable=broad-except
+            _LOGGER.exception("NWA50AX import validation failed for %s", user_input.get(CONF_HOST))
+            return self.async_abort(reason="cannot_connect")
+
+
+class ConnectionError(exceptions.HomeAssistantError):
+    """Error to indicate we cannot connect."""

--- a/custom_components/ha_zyxel/const.py
+++ b/custom_components/ha_zyxel/const.py
@@ -3,7 +3,9 @@ DEFAULT_NAME = "Zyxel Device"
 DEFAULT_HOST = "https://192.168.1.1"
 DEFAULT_USERNAME = "admin"
 DEFAULT_SCAN_INTERVAL = 30
+DEFAULT_DEVICE_TYPE = "legacy"
 
 CONF_HOST = "host"
 CONF_USERNAME = "username"
 CONF_PASSWORD = "password"
+CONF_DEVICE_TYPE = "device_type"

--- a/custom_components/ha_zyxel/manifest.json
+++ b/custom_components/ha_zyxel/manifest.json
@@ -10,5 +10,5 @@
   "requirements": [
     "nr7101@git+https://github.com/zulufoxtrot/nr7101.git@v2.0.2"
   ],
-  "version": "0.2.8"
+  "version": "0.3.0"
 }

--- a/custom_components/ha_zyxel/sensor.py
+++ b/custom_components/ha_zyxel/sensor.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from typing import Any
 
 from homeassistant.components.sensor import (
@@ -10,7 +11,8 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -18,6 +20,225 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from custom_components.ha_zyxel.const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
+
+_UPTIME_LEAF_KEYS = {"UpTime", "DSLUpTime", "ipoeConnectionUpTime", "pppoeConnectionUpTime"}
+_WLAN_HINT_TOKENS = ("wlan", "wifi", "wireless", "ssid", "channel", "radio", "band")
+_SENSITIVE_HINT_TOKENS = ("password", "passphrase", "psk", "wep", "key")
+_LANGUAGE_LIKE_VALUES = {"english", "french", "francais", "german", "deutsch", "spanish", "espanol"}
+_EX3301_WIFI_TOP_LEVEL_KEYS: set[str] = set()
+_EX3301_WIFIINFO_ALLOWED_LEAFS = {
+    "SSID",
+    "Channel",
+    "OperatingFrequencyBand",
+    "OperatingChannelBandwidth",
+    "OperatingStandards",
+    "X_ZYXEL_Rate",
+    "X_ZYXEL_MainSSID",
+}
+
+_NWA50AX_DEFAULT_LEAFS = {
+    "active",
+    "band",
+    "builddate",
+    "ethernet",
+    "firmwareversion",
+    "hostname",
+    "internet",
+    "ipaddress",
+    "ipv6dhcp6addressrequest",
+    "ipv6enable",
+    "ipv6gateway",
+    "ipv6metric",
+    "ipv6slaac",
+    "ipv6staticaddress",
+    "macaddress",
+    "mode",
+    "model",
+    "nebulacloudstatus",
+    "nebulantpstatus",
+    "serialnumber",
+    "slot0",
+    "slot1",
+    "slot2",
+    "slotactivate",
+    "slotchannelutilization",
+    "slotreceivedpktcount",
+    "slotslot1outputpower",
+    "slotslot2outputpower",
+    "slottransmittedpktcount",
+    "slottxpower",
+    "slotwlanreceivedbyte",
+    "slotwlantransmittedbyte",
+    "vlanid",
+    "vlantag",
+    "zyxelcloud",
+}
+
+
+def _normalize_leaf_name(value: str) -> str:
+    return re.sub(r"[^a-z0-9]", "", value.strip().lower())
+
+
+def _format_uptime_dms(value: Any) -> str | None:
+    """Format uptime seconds as <days>d <hours>h <minutes>m <seconds>s."""
+    try:
+        total_seconds = int(float(value))
+    except (TypeError, ValueError):
+        return None
+    if total_seconds < 0:
+        return None
+    days, rem = divmod(total_seconds, 86400)
+    hours, rem = divmod(rem, 3600)
+    minutes, seconds = divmod(rem, 60)
+    return f"{days}d {hours}h {minutes}m {seconds}s"
+
+
+def _looks_like_wlan_path(key: str) -> bool:
+    lowered = key.lower()
+    return any(token in lowered for token in _WLAN_HINT_TOKENS)
+
+
+def _is_sensitive_path(key: str) -> bool:
+    lowered = key.lower()
+    return any(token in lowered for token in _SENSITIVE_HINT_TOKENS)
+
+
+def _is_ex3301_wifi_sensor_key(key: str) -> bool:
+    """Return True for EX3301 WiFi keys we intentionally expose."""
+    if key in _EX3301_WIFI_TOP_LEVEL_KEYS:
+        return True
+    if not key.startswith("DAL?oid=cardpage_status.") or ".WiFiInfo." not in key:
+        return False
+    leaf = key.split(".")[-1]
+    return leaf in _EX3301_WIFIINFO_ALLOWED_LEAFS
+
+
+def _is_active_wifiinfo_path(flat: dict[str, Any], key: str) -> bool:
+    """Return True only for active WiFiInfo interfaces."""
+    if ".WiFiInfo." not in key:
+        return True
+    prefix = key.rsplit(".", 1)[0]
+    enabled = flat.get(f"{prefix}.Enable")
+    return bool(enabled)
+
+
+def _normalize_wifi_band(value: Any) -> str:
+    band = str(value or "").strip().lower()
+    if "2.4" in band:
+        return "2.4GHz"
+    if "5" in band:
+        return "5GHz"
+    return ""
+
+
+def _wifiinfo_prefixes(flat: dict[str, Any]) -> set[str]:
+    prefixes: set[str] = set()
+    for key in flat:
+        if ".WiFiInfo." not in key:
+            continue
+        prefixes.add(key.rsplit(".", 1)[0])
+    return prefixes
+
+
+def _wifi_profile_band_enabled(flat: dict[str, Any], *, main: bool, band: str) -> bool:
+    target_band = band.lower()
+    for prefix in _wifiinfo_prefixes(flat):
+        if not bool(flat.get(f"{prefix}.Enable")):
+            continue
+        is_main = bool(flat.get(f"{prefix}.X_ZYXEL_MainSSID"))
+        if is_main != main:
+            continue
+        radio_band = _normalize_wifi_band(flat.get(f"{prefix}.OperatingFrequencyBand")).lower()
+        if radio_band == target_band:
+            return True
+    return False
+
+
+def _ex3301_sensor_enabled_by_default(key: str) -> bool:
+    """Return True only for the EX3301 default-visible sensor allowlist."""
+    leaf = key.split(".")[-1]
+    if leaf in {"SoftwareVersion", "ModelName", "SerialNumber", "UpTime"}:
+        return True
+    if leaf == "DHCPStatus" and ".WanLanInfo.0." in key:
+        return True
+    if leaf == "v4dns":
+        return True
+    if leaf == "IPAddress" and (".WanLanInfo.2." in key or key.endswith(".Object.0.IPAddress")):
+        return True
+    if leaf == "pppConnectionStatus" and ".WanLanInfo.2." in key:
+        return True
+    if leaf == "EthConnectionStatus":
+        return True
+    if leaf == "v4Gateway" and ".WanLanInfo.2." in key:
+        return True
+    if leaf == "ipoeConnectionUpTime" and ".WanLanInfo.2." in key:
+        return True
+    if leaf == "pppoeConnectionUpTime" and ".WanLanInfo.2." in key:
+        return True
+    return False
+
+
+def _ex3301_wifi_label_for_key(flat: dict[str, Any], key: str) -> tuple[str, str]:
+    """Return (name, icon) for EX3301 WiFi key."""
+    leaf = key.split(".")[-1]
+    field_name = {
+        "SSID": "SSID",
+        "Channel": "Channel",
+        "OperatingFrequencyBand": "Frequency Band",
+        "OperatingChannelBandwidth": "Channel Bandwidth",
+        "OperatingStandards": "WiFi Standards",
+        "X_ZYXEL_Rate": "Link Rate",
+        "X_ZYXEL_MainSSID": "Main SSID",
+    }.get(leaf, leaf)
+    icon = {
+        "SSID": "mdi:wifi-settings",
+        "Channel": "mdi:access-point",
+        "OperatingFrequencyBand": "mdi:radio-tower",
+        "OperatingChannelBandwidth": "mdi:wifi-strength-3",
+        "OperatingStandards": "mdi:wifi",
+        "X_ZYXEL_Rate": "mdi:speedometer",
+        "X_ZYXEL_MainSSID": "mdi:wifi-check",
+    }.get(leaf, "mdi:wifi")
+
+    parts = key.split(".")
+    try:
+        i = parts.index("WiFiInfo")
+        slot = parts[i + 1]
+    except (ValueError, IndexError):
+        slot = "?"
+    prefix = key.rsplit(".", 1)[0]
+    is_main = bool(flat.get(f"{prefix}.X_ZYXEL_MainSSID"))
+    profile = "Private WiFi" if is_main else "Guest WiFi"
+    band = str(flat.get(f"{prefix}.OperatingFrequencyBand", "")).strip()
+    if band:
+        return f"{profile} {band} {field_name} (Radio {slot})", icon
+    return f"{profile} {field_name} (Radio {slot})", icon
+
+
+def _ex3301_section_prefix(key: str) -> str:
+    """Return a stable section prefix for EX3301 entity list grouping."""
+    leaf = key.split(".")[-1]
+    if leaf in {"SoftwareVersion", "HardwareVersion", "ModelName", "SerialNumber"}:
+        return "[Core] "
+    if leaf in {"DownstreamCurrRate", "UpstreamCurrRate", "DSLUpTime"}:
+        return "[DSL] "
+    if leaf in {"UpTime", "ipoeConnectionUpTime", "pppoeConnectionUpTime"}:
+        return "[Uptime] "
+    if leaf in {
+        "IPAddress",
+        "DefaultGateway",
+        "v4Gateway",
+        "v4dns",
+        "pppConnectionStatus",
+        "EthConnectionStatus",
+        "DHCPStatus",
+        "WanRate_RX",
+        "WanRate_TX",
+        "WanType",
+    }:
+        return "[Network] "
+    return ""
+
 
 # Define some known sensor types for proper configuration
 KNOWN_SENSORS = {
@@ -154,6 +375,216 @@ KNOWN_SENSORS = {
         "device_class": SensorDeviceClass.DATA_SIZE,
         "state_class": SensorStateClass.TOTAL_INCREASING,
     },
+    # ── EX3301-T0: Device info (DAL?oid=cardpage_status.Object.0.DeviceInfo) ──
+    "SoftwareVersion": {
+        "name": "Firmware Version",
+        "unit": None,
+        "icon": "mdi:information-outline",
+        "device_class": None,
+        "state_class": None,
+    },
+    "ModelName": {
+        "name": "Model",
+        "unit": None,
+        "icon": "mdi:router",
+        "device_class": None,
+        "state_class": None,
+    },
+    "SerialNumber": {
+        "name": "Serial Number",
+        "unit": None,
+        "icon": "mdi:barcode",
+        "device_class": None,
+        "state_class": None,
+    },
+    "UpTime": {
+        "name": "System Uptime",
+        "unit": "s",
+        "icon": "mdi:timer-outline",
+        "device_class": SensorDeviceClass.DURATION,
+        "state_class": SensorStateClass.TOTAL_INCREASING,
+    },
+    # ── EX3301-T0: DSL channel (DslChannelInfo.0) ──
+    "DownstreamCurrRate": {
+        "name": "DSL Downstream Rate",
+        "unit": "kbit/s",
+        "icon": "mdi:download-network",
+        "device_class": None,
+        "state_class": SensorStateClass.MEASUREMENT,
+    },
+    "UpstreamCurrRate": {
+        "name": "DSL Upstream Rate",
+        "unit": "kbit/s",
+        "icon": "mdi:upload-network",
+        "device_class": None,
+        "state_class": SensorStateClass.MEASUREMENT,
+    },
+    "DSLUpTime": {
+        "name": "DSL Uptime",
+        "unit": "s",
+        "icon": "mdi:timer-outline",
+        "device_class": SensorDeviceClass.DURATION,
+        "state_class": SensorStateClass.TOTAL_INCREASING,
+    },
+    # ── EX3301-T0: WAN summary (Object.0 level) ──
+    "WanRate_RX": {
+        "name": "WAN Receive Rate",
+        "unit": "kbit/s",
+        "icon": "mdi:download",
+        "device_class": None,
+        "state_class": SensorStateClass.MEASUREMENT,
+    },
+    "WanRate_TX": {
+        "name": "WAN Transmit Rate",
+        "unit": "kbit/s",
+        "icon": "mdi:upload",
+        "device_class": None,
+        "state_class": SensorStateClass.MEASUREMENT,
+    },
+    "WanType": {
+        "name": "WAN Type",
+        "unit": None,
+        "icon": "mdi:wan",
+        "device_class": None,
+        "state_class": None,
+    },
+    # ── EX3301-T0: WAN interface (WanLanInfo) ──
+    "IPAddress": {
+        "name": "IP Address",
+        "unit": None,
+        "icon": "mdi:ip-network",
+        "device_class": None,
+        "state_class": None,
+    },
+    "DefaultGateway": {
+        # This field is a boolean: True = this interface is the active default route.
+        "name": "Is Default Route",
+        "unit": None,
+        "icon": "mdi:routes",
+        "device_class": None,
+        "state_class": None,
+    },
+    "v4Gateway": {
+        "name": "WAN Gateway IP",
+        "unit": None,
+        "icon": "mdi:router-network",
+        "device_class": None,
+        "state_class": None,
+    },
+    "v4dns": {
+        "name": "DNS Server",
+        "unit": None,
+        "icon": "mdi:dns",
+        "device_class": None,
+        "state_class": None,
+    },
+    "pppConnectionStatus": {
+        "name": "PPP Connection Status",
+        "unit": None,
+        "icon": "mdi:connection",
+        "device_class": None,
+        "state_class": None,
+    },
+    "EthConnectionStatus": {
+        "name": "WAN Ethernet Status",
+        "unit": None,
+        "icon": "mdi:ethernet",
+        "device_class": None,
+        "state_class": None,
+    },
+    "ipoeConnectionUpTime": {
+        "name": "IPoE Connection Uptime",
+        "unit": "s",
+        "icon": "mdi:timer-outline",
+        "device_class": SensorDeviceClass.DURATION,
+        "state_class": SensorStateClass.TOTAL_INCREASING,
+    },
+    "pppoeConnectionUpTime": {
+        "name": "PPPoE Connection Uptime",
+        "unit": "s",
+        "icon": "mdi:timer-outline",
+        "device_class": SensorDeviceClass.DURATION,
+        "state_class": SensorStateClass.TOTAL_INCREASING,
+    },
+    "DHCPStatus": {
+        "name": "DHCP Status",
+        "unit": None,
+        "icon": "mdi:ip",
+        "device_class": None,
+        "state_class": None,
+    },
+    # ── EX3301-T0: Temperature (GponStatsInfo) ──
+    "Temperature": {
+        "name": "Device Temperature",
+        "unit": "°C",
+        "icon": "mdi:thermometer",
+        "device_class": SensorDeviceClass.TEMPERATURE,
+        "state_class": SensorStateClass.MEASUREMENT,
+    },
+    # ── EX3301-T0: WLAN settings (DAL?oid=wlan) ──
+    "WiFiSettings_wifikeepsame": {
+        "name": "Private WiFi Keep Same",
+        "unit": None,
+        "icon": "mdi:wifi-sync",
+        "device_class": None,
+        "state_class": None,
+    },
+    "WiFiSettings_onessid_24g_switch": {
+        "name": "Private WiFi 2.4G Enabled",
+        "unit": None,
+        "icon": "mdi:wifi",
+        "device_class": None,
+        "state_class": None,
+    },
+    "WiFiSettings_onessid_5g_switch": {
+        "name": "Private WiFi 5G Enabled",
+        "unit": None,
+        "icon": "mdi:wifi",
+        "device_class": None,
+        "state_class": None,
+    },
+    "WiFiSettings_both_wifiname": {
+        "name": "Private WiFi SSID",
+        "unit": None,
+        "icon": "mdi:wifi-settings",
+        "device_class": None,
+        "state_class": None,
+    },
+    "WiFiSettings_24g_randompw": {
+        "name": "Private WiFi 2.4G Random Password",
+        "unit": None,
+        "icon": "mdi:key-variant",
+        "device_class": None,
+        "state_class": None,
+    },
+    "WiFiSettings_both_randompw": {
+        "name": "Private WiFi Random Password",
+        "unit": None,
+        "icon": "mdi:key-variant",
+        "device_class": None,
+        "state_class": None,
+    },
+    "WiFiSettings_both_hidewifiname": {
+        "name": "Private WiFi Hide SSID",
+        "unit": None,
+        "icon": "mdi:wifi-hidden",
+        "device_class": None,
+        "state_class": None,
+    },
+    "Guest_WiFiSettings_both_wifiname": {
+        "name": "Guest WiFi SSID",
+        "unit": None,
+        "icon": "mdi:wifi-settings",
+        "device_class": None,
+        "state_class": None,
+    },
+    "Guest_WiFiSettings_both_hidewifiname": {
+        "name": "Guest WiFi Hide SSID",
+        "unit": None,
+        "icon": "mdi:wifi-hidden",
+        "device_class": None,
+        "state_class": None,
+    },
 }
 
 
@@ -164,6 +595,13 @@ def _flatten_dict(d: dict, parent_key: str = "") -> dict:
         new_key = f"{parent_key}.{k}" if parent_key else k
         if isinstance(v, dict):
             items.extend(_flatten_dict(v, new_key).items())
+        elif isinstance(v, list):
+            for i, item in enumerate(v):
+                list_key = f"{new_key}.{i}"
+                if isinstance(item, dict):
+                    items.extend(_flatten_dict(item, list_key).items())
+                else:
+                    items.append((list_key, item))
         else:
             items.append((new_key, v))
     return dict(items)
@@ -174,128 +612,380 @@ def _is_value_scalar(value: Any) -> bool:
     return isinstance(value, (str, int, float, bool)) or value is None
 
 
+def _looks_like_ip(value: str) -> bool:
+    parts = value.split(".")
+    if len(parts) != 4:
+        return False
+    try:
+        return all(0 <= int(p) <= 255 for p in parts)
+    except ValueError:
+        return False
+
+
+def _device_system_name(flat: dict[str, Any]) -> str | None:
+    """Return best host-readable system name for any Zyxel model."""
+    preferred_tokens = ("system name", "system_name", "systemname", "hostname", "fqdn", "device_name")
+    for key, value in flat.items():
+        if not isinstance(value, str):
+            continue
+        candidate = value.strip()
+        if not candidate:
+            continue
+        lowered = candidate.lower()
+        if lowered in _LANGUAGE_LIKE_VALUES:
+            continue
+        if _looks_like_ip(candidate):
+            continue
+        if lowered.startswith(("http://", "https://")):
+            continue
+        key_lower = key.lower()
+        if any(token in key_lower for token in preferred_tokens):
+            return candidate
+    return None
+
+
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Set up the Zyxel sensors."""
     coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
+    device_type = str(hass.data[DOMAIN][entry.entry_id].get("device_type", "legacy")).lower().replace(
+        "-",
+        "_",
+    )
 
     if not coordinator.data:
+        _LOGGER.warning("Zyxel coordinator has no data at sensor setup — no sensors created")
         return
 
+    flat = _flatten_dict(coordinator.data)
+    # Log available keys at INFO level to help tune sensor mappings.
+    _LOGGER.info(
+        "Zyxel (%s) available data keys (%d total): %s",
+        device_type,
+        len(flat),
+        sorted(flat.keys()),
+    )
     sensors = []
+    if device_type == "ex3301_t0":
+        wlan_keys = sorted(
+            key for key in flat if _looks_like_wlan_path(key) and not _is_sensitive_path(key)
+        )
+        _LOGGER.info(
+            "Zyxel (%s) WLAN-related data keys (%d total): %s",
+            device_type,
+            len(wlan_keys),
+            wlan_keys,
+        )
+        sensors.extend(
+            [
+                EX3301WiFiBandStateSensor(coordinator, entry, "Private", "2.4GHz", True),
+                EX3301WiFiBandStateSensor(coordinator, entry, "Private", "5GHz", True),
+                EX3301WiFiBandStateSensor(coordinator, entry, "Guest", "2.4GHz", False),
+                EX3301WiFiBandStateSensor(coordinator, entry, "Guest", "5GHz", False),
+            ]
+        )
 
-    # Process all keys in the JSON and create sensors for them
-    # We'll use a flat structure for simplicity
-    for key, value in _flatten_dict(coordinator.data).items():
-        # Skip non-scalar values
+    if device_type == "nwa50ax":
+        all_nwa_leafs = sorted(
+            {_normalize_leaf_name(k.split(".")[-1]) for k, v in flat.items() if _is_value_scalar(v) and not k.startswith("zyshdata")}
+        )
+        enabled_leafs = [l for l in all_nwa_leafs if l in _NWA50AX_DEFAULT_LEAFS]
+        disabled_leafs = [l for l in all_nwa_leafs if l not in _NWA50AX_DEFAULT_LEAFS]
+        _LOGGER.debug(
+            "NWA50AX (%s) leaf summary — total: %d, enabled-by-default: %d %s, disabled-by-default: %d %s",
+            entry.data.get("host", entry.entry_id),
+            len(all_nwa_leafs),
+            len(enabled_leafs),
+            enabled_leafs,
+            len(disabled_leafs),
+            disabled_leafs,
+        )
+
+    for key, value in flat.items():
         if not _is_value_scalar(value):
             continue
 
-        # Check if this is a known sensor type
-        sensor_config = KNOWN_SENSORS.get(key.split(".")[-1], None)
+        if device_type == "nwa50ax" and key.startswith("zyshdata"):
+            continue
+
+        # For EX3301, skip API fields that return null — these are firmware stubs
+        # (GPON temperature, WAN rate reporting, inactive DSL channels) that will
+        # never have useful data and only add clutter to the entity list.
+        if device_type == "ex3301_t0" and value is None:
+            continue
+
+        leaf = key.split(".")[-1]
+        sensor_config = KNOWN_SENSORS.get(leaf)
 
         if sensor_config:
-            # Create a configured sensor for known types
-            sensors.append(
-                ConfiguredZyxelSensor(
-                    coordinator,
-                    entry,
-                    key,
-                    sensor_config
-                )
-            )
-        else:
-            # Create a generic sensor for unknown types
-            sensors.append(
-                GenericZyxelSensor(
-                    coordinator,
-                    entry,
-                    key
-                )
-            )
+            sensors.append(ConfiguredZyxelSensor(coordinator, entry, key, sensor_config))
+        elif (
+            device_type == "ex3301_t0"
+            and _is_ex3301_wifi_sensor_key(key)
+            and not _is_sensitive_path(key)
+            and _is_active_wifiinfo_path(flat, key)
+            and str(value).strip().lower() != "unknown"
+        ):
+            sensors.append(EX3301WiFiSensor(coordinator, entry, key))
+        elif device_type != "ex3301_t0":
+            # Generic sensors for legacy/NWA50AX — avoid flooding HA for EX3301
+            # whose responses contain deeply-nested arrays with hundreds of fields.
+            sensors.append(GenericZyxelSensor(coordinator, entry, key))
 
-    if sensors:
+    # Remove stale entity registry entries that are no longer being created
+    # (e.g. sensors suppressed by the null-value filter on this reload).
+    current_unique_ids = {s.unique_id for s in sensors}
+    ent_reg = er.async_get(hass)
+    config_entries = list(er.async_entries_for_config_entry(ent_reg, entry.entry_id))
+    for reg_entry in config_entries:
+        if reg_entry.unique_id not in current_unique_ids:
+            _LOGGER.debug("Removing stale entity %s", reg_entry.entity_id)
+            ent_reg.async_remove(reg_entry.entity_id)
+
+    # Migration cleanup: force recreation of entities that were created with the
+    # old Zyxel-prefixed naming so the new device/entity names can take effect.
+    for reg_entry in config_entries:
+        if reg_entry.entity_id.startswith(("sensor.zyxel_", "button.zyxel_")):
+            _LOGGER.debug("Removing legacy prefixed entity for rename migration: %s", reg_entry.entity_id)
+            ent_reg.async_remove(reg_entry.entity_id)
+
+    # Migration cleanup: purge legacy generic EX3301 entities created by older
+    # builds for the same physical device under a different config_entry_id.
+    # These have entity IDs like sensor.zyxel_dal_oid_... and are no longer used.
+    if device_type == "ex3301_t0":
+        current_device_ids = {reg.device_id for reg in config_entries if reg.device_id}
+        if current_device_ids:
+            for reg_entry in list(ent_reg.entities.values()):
+                if reg_entry.platform != DOMAIN:
+                    continue
+                if reg_entry.config_entry_id == entry.entry_id:
+                    continue
+                if reg_entry.device_id not in current_device_ids:
+                    continue
+                if reg_entry.entity_id.startswith("sensor.zyxel_dal_oid_"):
+                    _LOGGER.debug(
+                        "Removing legacy EX3301 generic entity from old entry: %s",
+                        reg_entry.entity_id,
+                    )
+                    ent_reg.async_remove(reg_entry.entity_id)
+
+    if not sensors:
+        _LOGGER.warning(
+            "Zyxel (%s): no sensors matched KNOWN_SENSORS — check the data keys log above",
+            device_type,
+        )
+    else:
+        _LOGGER.debug("Zyxel sensor setup: creating %d sensors for %s", len(sensors), device_type)
         async_add_entities(sensors)
 
 
 class AbstractZyxelSensor(CoordinatorEntity, SensorEntity):
     """Base class for Zyxel device sensors."""
 
+    _attr_has_entity_name = True
+
     def __init__(self, coordinator, entry: ConfigEntry, key: str):
         """Initialize the sensor."""
         super().__init__(coordinator)
         self._key = key
-        self._attr_unique_id = f"{entry.entry_id}_{key}"
+        # Pre-populate immediately in case the coordinator already refreshed
+        # before this sensor was registered (sensors are created after first_refresh).
+        self._flat_state: dict[str, Any] = (
+            _flatten_dict(coordinator.data) if coordinator.data else {}
+        )
+        safe_key = key.replace("?", "_").replace("=", "_").replace("&", "_").replace(" ", "_")
+        self._attr_unique_id = f"{entry.entry_id}_{safe_key}"
+        flat = self._flat_state
+        # flat has full-path keys; search by leaf name (first match wins).
+        leaf_vals: dict[str, Any] = {}
+        for k, v in flat.items():
+            leaf = k.split(".")[-1]
+            if leaf not in leaf_vals:
+                leaf_vals[leaf] = v
+        model = (
+            leaf_vals.get("ModelName")
+            or leaf_vals.get("ProductClass")
+            or leaf_vals.get("HardwareVersion")
+            or entry.data.get("device_type", "").upper().replace("_", "-")
+            or entry.data.get("host", "")
+        )
+        sw_version = leaf_vals.get("SoftwareVersion") or leaf_vals.get("FirmwareVersion")
+        host = str(entry.data.get("host", "")).replace("http://", "").replace("https://", "")
+        host = host.split("/", 1)[0]
+        display_name = _device_system_name(flat) or (f"Zyxel {host}" if host else f"Zyxel {model}")
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, entry.entry_id)},
-            name=f"Zyxel ({entry.data['host']})",
+            name=display_name,
             manufacturer="Zyxel",
-            model="",
+            model=model,
+            sw_version=sw_version,
         )
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Refresh flat-state cache then write HA state."""
+        if self.coordinator.data:
+            self._flat_state = _flatten_dict(self.coordinator.data)
+        self.async_write_ha_state()
 
     @property
     def available(self) -> bool:
         """Return if entity is available."""
-        if not self.coordinator.last_update_success:
+        if not self.coordinator.last_update_success or not self.coordinator.data:
             return False
-
-        # Check if the key exists in the data
-        try:
-            self._get_value_from_path()
-            return True
-        except (KeyError, AttributeError):
-            return False
+        return self._key in self._flat_state
 
     def _get_value_from_path(self) -> Any:
-        """Get a value from nested dictionaries using the flattened key."""
-        keys = self._key.split(".")
-        value = self.coordinator.data
-        for k in keys:
-            value = value[k]
-        return value
+        """Return the value from the cached flat state."""
+        return self._flat_state[self._key]
 
 
 class ConfiguredZyxelSensor(AbstractZyxelSensor):
     """Representation of a configured Zyxel sensor."""
 
+    # Human-readable labels for known array-parent names.
+    _PARENT_LABELS: dict[str, str] = {
+        "DslChannelInfo": "DSL Ch",
+        "WanLanInfo": "WAN",
+        "LanInfo": "LAN",
+        "LanPortInfo": "LAN Port",
+        "dnsv4Server": "DNS",
+        "IPv4Address": "",
+        "Object": "",
+    }
+
+    @classmethod
+    def _path_suffix(cls, key: str) -> str:
+        """Return a disambiguating suffix for keys that appear at multiple array indices.
+
+        Scans the path right-to-left for the first numeric component whose
+        named parent maps to a non-empty label, skipping 'Object' and parents
+        mapped to '' (e.g. IPv4Address) so we bubble up to a more meaningful
+        ancestor like WanLanInfo.
+        """
+        parts = key.split(".")
+        for i in range(len(parts) - 2, 0, -1):
+            if parts[i].isdigit() and not parts[i - 1].isdigit():
+                parent = parts[i - 1]
+                if parent == "Object":
+                    continue
+                if parent == "WanLanInfo":
+                    if parts[i] == "0":
+                        return " (LAN)"
+                    return f" (WAN {parts[i]})"
+                prefix = cls._PARENT_LABELS.get(parent, parent)
+                if prefix == "":
+                    continue  # uninformative parent (e.g. IPv4Address) — keep scanning
+                label = f"{prefix} {parts[i]}".strip()
+                return f" ({label})" if label else ""
+        return ""
+
     def __init__(self, coordinator, entry: ConfigEntry, key: str, config: dict):
         """Initialize the sensor."""
         super().__init__(coordinator, entry, key)
         self._config = config
-        self._attr_name = f"Zyxel {config['name']}"
-        self._attr_native_unit_of_measurement = config["unit"]
+        self._is_uptime = key.split(".")[-1] in _UPTIME_LEAF_KEYS
+        device_type = str(entry.data.get("device_type", "")).lower().replace("-", "_")
+        prefix = _ex3301_section_prefix(key) if device_type == "ex3301_t0" else ""
+        self._attr_name = f"{prefix}{config['name']}{self._path_suffix(key)}"
+        if device_type == "ex3301_t0":
+            self._attr_entity_registry_enabled_default = _ex3301_sensor_enabled_by_default(key)
+        self._attr_native_unit_of_measurement = None if self._is_uptime else config["unit"]
         self._attr_icon = config["icon"]
-        self._attr_device_class = config["device_class"]
-        self._attr_state_class = config["state_class"]
+        self._attr_device_class = None if self._is_uptime else config["device_class"]
+        self._attr_state_class = None if self._is_uptime else config["state_class"]
 
     @property
     def state(self):
-        """Return the state of the sensor."""
+        """Return the state of the sensor, or None for empty strings."""
         try:
-            return self._get_value_from_path()
-        except (KeyError, AttributeError):
+            value = self._get_value_from_path()
+            if value == "":
+                return None
+            if self._is_uptime:
+                return _format_uptime_dms(value)
+            return value
+        except (KeyError, AttributeError, TypeError, IndexError, ValueError):
             return None
 
 
 class GenericZyxelSensor(AbstractZyxelSensor):
     """Representation of a generic Zyxel sensor."""
 
+    def __init__(self, coordinator, entry: ConfigEntry, key: str):
+        super().__init__(coordinator, entry, key)
+        device_type = str(entry.data.get("device_type", "")).lower().replace("-", "_")
+        if device_type == "nwa50ax":
+            leaf = _normalize_leaf_name(key.split(".")[-1])
+            self._attr_entity_registry_enabled_default = leaf in _NWA50AX_DEFAULT_LEAFS
+
     @property
     def name(self):
         """Return the name of the sensor."""
         name_parts = self._key.split(".")
-        return f"Zyxel {'.'.join(name_parts)}"
+        return ".".join(name_parts)
 
     @property
     def state(self):
-        """Return the state of the sensor."""
+        """Return the state of the sensor, or None for empty strings."""
         try:
-            return self._get_value_from_path()
-        except (KeyError, AttributeError):
+            value = self._get_value_from_path()
+            return value if value != "" else None
+        except (KeyError, AttributeError, TypeError, IndexError, ValueError):
             return None
 
     @property
     def icon(self):
         """Return the icon."""
         return "mdi:router-wireless"
+
+
+class EX3301WiFiSensor(AbstractZyxelSensor):
+    """Friendly-named WiFi telemetry sensor for EX3301."""
+
+    def __init__(self, coordinator, entry: ConfigEntry, key: str):
+        super().__init__(coordinator, entry, key)
+        name, icon = _ex3301_wifi_label_for_key(self._flat_state, key)
+        self._attr_name = f"[WiFi] {name}"
+        self._attr_icon = icon
+        self._attr_entity_registry_enabled_default = False
+
+    @property
+    def state(self):
+        """Return the state of the sensor, or None for empty strings."""
+        try:
+            value = self._get_value_from_path()
+            return value if value != "" else None
+        except (KeyError, AttributeError, TypeError, IndexError, ValueError):
+            return None
+
+
+class EX3301WiFiBandStateSensor(AbstractZyxelSensor):
+    """Derived EX3301 sensor for private/guest WiFi enabled per band."""
+
+    def __init__(self, coordinator, entry: ConfigEntry, profile: str, band: str, main: bool):
+        key = f"EX3301.WiFi.{profile}.{band}.Enabled"
+        super().__init__(coordinator, entry, key)
+        self._profile = profile
+        self._band = band
+        self._main = main
+        self._attr_name = f"[WiFi] {profile} WiFi {band} Enabled"
+        self._attr_icon = "mdi:wifi-check"
+        self._attr_entity_registry_enabled_default = True
+
+    @property
+    def available(self) -> bool:
+        return bool(self.coordinator.last_update_success and self.coordinator.data)
+
+    @property
+    def state(self):
+        try:
+            flat = _flatten_dict(self.coordinator.data) if self.coordinator.data else {}
+            return _wifi_profile_band_enabled(
+                flat,
+                main=self._main,
+                band=self._band,
+            )
+        except (TypeError, ValueError, AttributeError):
+            return None

--- a/custom_components/ha_zyxel/strings.json
+++ b/custom_components/ha_zyxel/strings.json
@@ -1,0 +1,9 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "description": "Select Device Type"
+      }
+    }
+  }
+}

--- a/custom_components/ha_zyxel/strings.json
+++ b/custom_components/ha_zyxel/strings.json
@@ -2,8 +2,40 @@
   "config": {
     "step": {
       "user": {
-        "description": "Select Device Type"
+        "description": "Select Device Type",
+        "data": {
+          "device_type": "Device Type"
+        }
+      },
+      "legacy": {
+        "data": {
+          "host": "IP Address",
+          "username": "Username",
+          "password": "Password"
+        }
+      },
+      "nwa50ax": {
+        "data": {
+          "host": "IP Address / Addresses (comma-separated)",
+          "username": "Username (usually 'admin')",
+          "password": "Password"
+        }
+      },
+      "ex3301_t0": {
+        "data": {
+          "host": "IP Address",
+          "username": "Username (usually 'admin')",
+          "password": "Password"
+        }
       }
+    },
+    "error": {
+      "cannot_connect": "Failed to connect",
+      "invalid_auth": "Invalid authentication",
+      "unknown": "Unexpected error"
+    },
+    "abort": {
+      "already_configured": "Device is already configured"
     }
   }
 }

--- a/custom_components/ha_zyxel/translations/en.json
+++ b/custom_components/ha_zyxel/translations/en.json
@@ -3,8 +3,27 @@
     "step": {
       "user": {
         "data": {
-          "host": "Host",
+          "device_type": "Device Type"
+        }
+      },
+      "nwa50ax": {
+        "data": {
+          "host": "IP Address / Addresses (comma-separated)",
           "username": "Username (usually 'admin')",
+          "password": "Password"
+        }
+      },
+      "ex3301_t0": {
+        "data": {
+          "host": "IP Address",
+          "username": "Username (usually 'admin')",
+          "password": "Password"
+        }
+      },
+      "legacy": {
+        "data": {
+          "host": "IP Address",
+          "username": "Username",
           "password": "Password"
         }
       }

--- a/custom_components/ha_zyxel/translations/fr.json
+++ b/custom_components/ha_zyxel/translations/fr.json
@@ -3,8 +3,27 @@
     "step": {
       "user": {
         "data": {
-          "host": "Hôte",
+          "device_type": "Type d'appareil"
+        }
+      },
+      "nwa50ax": {
+        "data": {
+          "host": "Adresse IP / Adresses (séparées par une virgule)",
           "username": "Nom d'utilisateur (habituellement 'admin')",
+          "password": "Mot de passe"
+        }
+      },
+      "ex3301_t0": {
+        "data": {
+          "host": "Adresse IP",
+          "username": "Nom d'utilisateur (habituellement 'admin')",
+          "password": "Mot de passe"
+        }
+      },
+      "legacy": {
+        "data": {
+          "host": "Adresse IP",
+          "username": "Nom d'utilisateur",
           "password": "Mot de passe"
         }
       }


### PR DESCRIPTION
## Summary
This PR strengthens model-specific support for EX3301-T0 and NWA50AX while keeping
the original legacy flow intact. It also cleans up entity naming.

## Config flow changes (shared + model-specific)
- Kept the original legacy config path for existing generic-supported devices.
- Added dedicated per-model setup/validation paths for NWA50AX and EX3301-T0.

## EX3301-T0 changes
### Connectivity/runtime
- Hardened EX3301 login/session flow.
- Added encrypted CGI response decryption handling.
- Improved probe strategy and session-expiry recovery (re-login + retry).
- Increased EX3301 polling timeout for multi-endpoint status collection.

### Entity model
- Replaced broad generic flattening with curated/mapped entity creation.
- Added stale entity cleanup for no-longer-created entities.
- Added migration cleanup for old sensor.zyxel_dal_oid_* entities.
- Normalised device_type aliases so EX3301 always follows EX3301-specific logic.

### EX3301 entity coverage
- Device info: firmware, hardware, model, serial, uptime.
- WAN/LAN: IPs, gateway, route status, PPP status, Ethernet status, DNS, DHCP.
- Uptime/connection durations formatted as d/h/m/s.
- Curated Wi-Fi telemetry: guest Wi-Fi enabled, one SSID mode, SSID/channel/band/bandwidth/
  standards/link rate/main SSID per active radio.
- Excludes noisy/sensitive/unhelpful WLAN fields and raw DAL-style clutter.

## NWA50AX changes
### Connectivity/runtime
- Preserved NWA50AX zysh-cgi behaviour and model-specific validation flow.
- Added multi-device onboarding from a single comma/newline-separated field.
- Each address creates its own config entry using the same username/password.
- Ensured host normalisation and correct AP client routing.
- NWA50AX now exposes the supplied AP/status sensors by default and keeps the rest disabled.
- NWA50AX ignores noisy `zyshdata*` duplicates in the generic entity set.

### Entity model
- NWA50AX continues to expose AP-focused telemetry through dynamic status normalisation,
  including WLAN/radio status, channel/wireless-hal derived state, Nebula status surfaces,
  and device identity/status fields.

## Shared improvements
- Each config entry is isolated at the device level; EX3301, NWA50AX, and legacy devices
  are tracked separately, not as one combined device.
- Improved naming consistency (model-aware integration/group context, stable host/IP-based
  device identity).

## Additional changes
- Removed `Zyxel` prefix from integration/group titles (new and migrated existing entries on reload).
- Fixed NWA50AX title detection to avoid locale placeholders like `English`; now prefers
  model/system-name values.
- Unified device naming policy across all models: system-name-first with host/model fallback,
  applied consistently in sensor and button platforms.
- Removed duplicate EX3301 `Hardware Version` sensor.
- Added EX3301 default-enabled allowlist so only essential Core/Network/Uptime/WiFi state
  sensors are enabled by default.
- Added EX3301 WiFi profile-band state sensors (Private/Guest × 2.4GHz/5GHz) and automatic
  entry reload when WiFi radio layout changes.
- Curated EX3301 WiFi entities use friendly names grouped by Private/Guest + band + radio;
  raw `DAL?oid=...` WiFi clutter removed.
- Uptime sensors display in d/h/m/s format.

## User-visible outcomes
- Clear setup: pick device type first, then model-specific flow.
- Cleaner EX3301 entities (major noise reduction).
- NWA50AX behaviour retained and aligned with shared logic.
- Stable entity lifecycle across reloads/upgrades.
- Legacy device behaviour remains unchanged except for the initial device picker.

## Attribution
- This PR was coded with assistance from GitHub Copilot.
